### PR TITLE
refactor router mounting

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,5 @@
-from app.routers import plan, sizing
-from app.routers import diag_config
 from fastapi import FastAPI
+import logging
 
 app = FastAPI(title="Trading Assistant", version="0.0.1")
 
@@ -20,43 +19,46 @@ app.add_middleware(
 )
 # --- end CORS ---
 
-app.include_router(sizing.router, prefix="/api/v1")
-app.include_router(plan.router, prefix="/api/v1")
-app.include_router(diag_config.router)
 
 @app.get("/healthz")
 def healthz():
     return {"ok": True}
 
+
 @app.get("/api/v1/diag/health")
 def diag_health():
     return {"ok": True, "status": "healthy"}
 
+
 @app.get("/api/v1/diag/ready")
 def diag_ready():
     return {"ok": True, "ready": True}
+
+
+logger = logging.getLogger(__name__)
+
 
 def _mount(module: str, attr: str = "router", prefix: str = "/api/v1"):
     try:
         mod = __import__(module, fromlist=[attr])
         r = getattr(mod, attr)
         app.include_router(r, prefix=prefix)
-        print(f"[boot] mounted {module}")
+        logger.info("[boot] mounted %s", module)
     except Exception as e:
-        print(f"[boot] skipping {module}: {e}")
+        logger.exception("[boot] skipping %s: %s", module, e)
 
-# core routers (mount once)
-_mount("app.routers.diag")           # if present in your repo
-_mount("app.routers.diag_config")    # if present
-_mount("app.routers.screener")       # if present
-_mount("app.routers.options")        # we just created this
-_mount("app.routers.alerts")         # if present
-_mount("app.routers.plan")           # if present
-_mount("app.routers.sizing")         # if present
-_mount("app.routers.admin")          # if present
 
-# assistant router (simple)
-_mount("app.routers.assistant_simple")
+ROUTER_MODULES = [
+    "app.routers.diag",
+    "app.routers.diag_config",
+    "app.routers.screener",
+    "app.routers.options",
+    "app.routers.alerts",
+    "app.routers.plan",
+    "app.routers.sizing",
+    "app.routers.admin",
+    "app.routers.assistant_simple",
+]
 
-from app.routers import screener as screener_router
-app.include_router(screener_router.router, prefix="/api/v1")
+for module_path in ROUTER_MODULES:
+    _mount(module_path)


### PR DESCRIPTION
## Summary
- centralize router module definitions in `app/main.py`
- loop over router modules and log mount success or failure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c3a0dde9a88320863e03ec8909f962