### PR TITLE
Refactor Tradier client management

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from app.routers import plan, sizing
 from app.routers import diag_config
 from fastapi import FastAPI
+from app.services.providers import close_tradier_client
 
 app = FastAPI(title="Trading Assistant", version="0.0.1")
 
@@ -60,3 +61,8 @@ _mount("app.routers.assistant_simple")
 
 from app.routers import screener as screener_router
 app.include_router(screener_router.router, prefix="/api/v1")
+
+
+@app.on_event("shutdown")
+async def _shutdown_tradier():
+    await close_tradier_client()

--- a/tests/test_options_dependency.py
+++ b/tests/test_options_dependency.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.routers import options
+
+
+def test_options_pick_injects_client(monkeypatch):
+    monkeypatch.setattr(options, "TRADIER_TOKEN", "token")
+    class DummyClient:
+        def __init__(self):
+            self.closed = False
+        async def close(self):
+            self.closed = True
+
+    mock_client = DummyClient()
+
+    async def override_client():
+        try:
+            yield mock_client
+        finally:
+            await mock_client.close()
+
+    app.dependency_overrides[options.get_tradier_client] = override_client
+
+    async def fake_pick(client, symbol, side, horizon, n):
+        assert client is mock_client
+        return options.OptionsPickResponse(ok=True, env="test", count_considered=0, picks=[], source="tradier")
+
+    monkeypatch.setattr(options, "_pick_from_tradier", fake_pick)
+
+    with TestClient(app) as test_client:
+        resp = test_client.post("/api/v1/options/pick", json={"symbol": "AAPL", "side": "long_call"})
+        assert resp.status_code == 200
+        assert mock_client.closed is True
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- inject `TradierClient` per request in the options router and close it automatically
- allow service helpers to accept a provided Tradier client and close the module-level instance on shutdown
- add test covering dependency override and client cleanup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c3a0deac348320b35af98629f7bbc4