### PR TITLE
Add streaming broker endpoints and dashboard WebSocket client

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Environment
+
+The backend reads the following environment variables:
+
+- `TRADIER_BASE` – Tradier API base URL (defaults to sandbox)
+- `TRADIER_TOKEN` – Tradier access token
+- `POLYGON_API_KEY` – optional key for Polygon quotes
+- `DATA_MODE`
+- `WS_PING_SEC`
+- `RISK_MAX_DAILY_R`
+- `RISK_MAX_CONCURRENT`
+
+`/api/v1/diag/config` reports whether each value is loaded.
+
+## WebSocket
+
+Run the FastAPI app with `uvicorn app.main:app`. The dashboard connects to
+`ws://<host>/ws` for live updates. Heartbeats are sent every `WS_PING_SEC`
+seconds, and the connection manager drops unresponsive sockets.

--- a/app/core/risk.py
+++ b/app/core/risk.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+from typing import Any, Dict
+from .ws import manager
+from app.services import tradier
+
+RISK_MAX_DAILY_R = float(os.getenv("RISK_MAX_DAILY_R", "0"))
+RISK_MAX_CONCURRENT = int(os.getenv("RISK_MAX_CONCURRENT", "0"))
+
+class RiskEngine:
+    def __init__(self) -> None:
+        self.state: Dict[str, Any] = {
+            "daily_r": 0.0,
+            "concurrent": 0,
+            "breach_daily_r": False,
+            "breach_concurrent": False,
+        }
+
+    async def refresh(self) -> None:
+        pos = await tradier.get_positions()
+        items = pos.get("items", []) if isinstance(pos, dict) else []
+        concurrent = len(items)
+        self.state["concurrent"] = concurrent
+        self.state["breach_concurrent"] = bool(RISK_MAX_CONCURRENT and concurrent > RISK_MAX_CONCURRENT)
+        self.state["breach_daily_r"] = bool(RISK_MAX_DAILY_R and self.state["daily_r"] > RISK_MAX_DAILY_R)
+
+    async def loop(self) -> None:
+        while True:
+            try:
+                await self.refresh()
+                await manager.broadcast_json({"type": "risk", "state": self.state})
+            except Exception:
+                pass
+            await asyncio.sleep(15)
+
+risk_engine = RiskEngine()
+
+async def start_risk_engine() -> None:
+    asyncio.create_task(risk_engine.loop())

--- a/app/core/ws.py
+++ b/app/core/ws.py
@@ -1,0 +1,49 @@
+import asyncio
+from typing import List
+from fastapi import WebSocket, WebSocketDisconnect
+import os
+
+WS_PING_SEC = int(os.getenv("WS_PING_SEC", "20"))
+
+class WSManager:
+    """Minimal WebSocket connection manager."""
+
+    def __init__(self) -> None:
+        self.connections: List[WebSocket] = []
+
+    async def connect(self, ws: WebSocket) -> None:
+        await ws.accept()
+        self.connections.append(ws)
+
+    def disconnect(self, ws: WebSocket) -> None:
+        if ws in self.connections:
+            self.connections.remove(ws)
+
+    async def broadcast_json(self, data: dict) -> None:
+        for ws in list(self.connections):
+            try:
+                await ws.send_json(data)
+            except Exception:
+                self.disconnect(ws)
+
+    async def ping_task(self) -> None:
+        while True:
+            await asyncio.sleep(WS_PING_SEC)
+            for ws in list(self.connections):
+                try:
+                    await ws.send_json({"type": "ping"})
+                except Exception:
+                    self.disconnect(ws)
+
+manager = WSManager()
+
+async def websocket_endpoint(ws: WebSocket) -> None:
+    await manager.connect(ws)
+    try:
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(ws)
+
+async def start_ws() -> None:
+    asyncio.create_task(manager.ping_task())

--- a/app/routers/auto.py
+++ b/app/routers/auto.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Body
+from app.services import tradier
+from app.core.risk import risk_engine
+from app.core.ws import manager
+
+router = APIRouter(prefix="/auto", tags=["auto"])
+
+@router.post("/execute")
+async def auto_execute(body: dict = Body(...)):
+    confirm = body.get("confirm", False)
+    symbol = body.get("symbol")
+    side = body.get("side")
+    entry = body.get("entry")
+    stop = body.get("stop")
+    risk_r = body.get("risk_R", 1)
+
+    if risk_engine.state.get("breach_concurrent") or risk_engine.state.get("breach_daily_r"):
+        await manager.broadcast_json({"type": "alert", "level": "danger", "msg": "risk_blocked"})
+        return {"ok": False, "error": "risk_blocked", "state": risk_engine.state}
+
+    size = 1  # placeholder sizing
+    review = {"symbol": symbol, "side": side, "qty": size, "entry": entry, "stop": stop, "risk_R": risk_r}
+    if not confirm:
+        return {"ok": True, "pending": True, "review": review}
+
+    res = await tradier.submit_order(symbol, side, size, "market")
+    if res.get("ok"):
+        ords = await tradier.get_orders()
+        await manager.broadcast_json({"type": "orders", "items": ords.get("items", [])})
+        await manager.broadcast_json({"type": "alert", "level": "info", "msg": f"Order submitted for {symbol}"})
+    return res

--- a/app/routers/broker.py
+++ b/app/routers/broker.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Body
+from app.services import tradier
+from app.core.ws import manager
+
+router = APIRouter(prefix="/broker", tags=["broker"])
+
+@router.get("/positions")
+async def get_positions():
+    return await tradier.get_positions()
+
+@router.get("/orders")
+async def get_orders():
+    return await tradier.get_orders()
+
+@router.post("/orders/submit")
+async def submit_order(body: dict = Body(...)):
+    res = await tradier.submit_order(
+        body.get("symbol"),
+        body.get("side"),
+        int(body.get("qty", 0)),
+        body.get("order_type"),
+        body.get("limit_price"),
+        body.get("stop_price"),
+    )
+    if res.get("ok"):
+        pos = await tradier.get_positions()
+        ords = await tradier.get_orders()
+        await manager.broadcast_json({"type": "positions", "items": pos.get("items", [])})
+        await manager.broadcast_json({"type": "orders", "items": ords.get("items", [])})
+    return res
+
+@router.post("/orders/cancel")
+async def cancel_order(body: dict = Body(...)):
+    res = await tradier.cancel_order(body.get("order_id"))
+    if res.get("ok"):
+        ords = await tradier.get_orders()
+        await manager.broadcast_json({"type": "orders", "items": ords.get("items", [])})
+    return res
+
+@router.post("/webhook")
+async def broker_webhook(body: dict = Body(...)):
+    # For now we simply log and acknowledge
+    print("broker webhook", body)
+    return {"ok": True}

--- a/app/routers/stream.py
+++ b/app/routers/stream.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+from app.services import tradier
+from app.core.risk import risk_engine
+
+router = APIRouter(prefix="/stream", tags=["stream"])
+
+@router.get("/state")
+async def stream_state():
+    pos = await tradier.get_positions()
+    ords = await tradier.get_orders()
+    return {
+        "ok": True,
+        "positions": pos.get("items", []),
+        "orders": ords.get("items", []),
+        "risk": risk_engine.state,
+    }
+
+@router.get("/risk/state")
+async def risk_state():
+    return {"ok": True, "state": risk_engine.state}

--- a/app/services/polygon.py
+++ b/app/services/polygon.py
@@ -18,3 +18,13 @@ def get_json(path: str, params: Dict[str, Any] | None=None) -> Dict[str, Any]:
     if r.status_code >= 400:
         raise PolygonError(f"HTTP {r.status_code}: {r.text[:300]}")
     return r.json()
+
+def last_quote(symbol: str) -> Dict[str, Any]:
+    """Return last trade price for symbol."""
+    try:
+        js = get_json(f"/v2/last/trade/{symbol}")
+        price = js.get("results", {}).get("p")
+        ts = js.get("results", {}).get("t")
+        return {"ok": True, "symbol": symbol, "last": price, "ts": ts}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,8 @@
+# Dashboard
+
+## Checklist
+- WebSocket status shows "Connected" when backend is running.
+- Positions and Orders pages update live without refresh.
+- Toast appears when an `alert` message is received over WebSocket.
+
+Run with `pnpm dev` from this directory.

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -1,5 +1,6 @@
 import QueryProvider from "@/src/lib/query-provider";
 import "./globals.css";
+import { Toaster } from "sonner";
 
 export const metadata = { title: "Trading Assistant Dashboard" };
 
@@ -13,6 +14,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </div>
         <div className="container">
           <QueryProvider>{children}</QueryProvider>
+          <Toaster position="top-right" />
         </div>
       </body>
     </html>

--- a/dashboard/app/orders/page.tsx
+++ b/dashboard/app/orders/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useOrders } from "@/src/lib/store";
+import { apiPost } from "@/src/lib/api";
+import { useState } from "react";
+
+export default function OrdersPage() {
+  const orders = useOrders();
+  const [symbol, setSymbol] = useState("SPY");
+
+  const submit = async () => {
+    await apiPost("/api/v1/broker/orders/submit", {
+      symbol,
+      side: "buy",
+      qty: 1,
+      order_type: "market",
+    });
+  };
+
+  const cancel = async (id: string) => {
+    await apiPost("/api/v1/broker/orders/cancel", { order_id: id });
+  };
+
+  return (
+    <main className="container">
+      <h1>Orders</h1>
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        <input value={symbol} onChange={(e) => setSymbol(e.target.value)} className="input" />
+        <button onClick={submit}>Paper Trade</button>
+      </div>
+      <ul>
+        {orders.map((o: any) => (
+          <li key={o.id}>
+            {o.symbol} – {o.status}
+            {o.id && (
+              <button style={{ marginLeft: 8 }} onClick={() => cancel(o.id)}>
+                Cancel
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/dashboard/app/positions/page.tsx
+++ b/dashboard/app/positions/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { usePositions } from "@/src/lib/store";
+
+export default function PositionsPage() {
+  const positions = usePositions();
+  return (
+    <main className="container">
+      <h1>Positions</h1>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Symbol</th>
+            <th>Qty</th>
+            <th>Avg</th>
+          </tr>
+        </thead>
+        <tbody>
+          {positions.map((p: any) => (
+            <tr key={p.symbol}>
+              <td>{p.symbol}</td>
+              <td>{p.qty}</td>
+              <td>{p.avg_price}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/dashboard/app/risk/page.tsx
+++ b/dashboard/app/risk/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { useRisk } from "@/src/lib/store";
+
+export default function RiskPage() {
+  const risk = useRisk() || {};
+  return (
+    <main className="container">
+      <h1>Risk</h1>
+      <pre>{JSON.stringify(risk, null, 2)}</pre>
+    </main>
+  );
+}

--- a/dashboard/app/signals/page.tsx
+++ b/dashboard/app/signals/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useEffect, useState } from "react";
+import { apiGet } from "@/src/lib/api";
+
+export default function SignalsPage() {
+  const [signals, setSignals] = useState<any[]>([]);
+  useEffect(() => {
+    const fetchSignals = async () => {
+      try {
+        const r = await apiGet("/api/v1/admin/signals");
+        setSignals(r.items || []);
+      } catch {
+        /* ignore */
+      }
+    };
+    fetchSignals();
+    const t = setInterval(fetchSignals, 20000);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <main className="container">
+      <h1>Signals</h1>
+      <ul>
+        {signals.map((s: any, i) => (
+          <li key={i}>{JSON.stringify(s)}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/dashboard/src/lib/store.ts
+++ b/dashboard/src/lib/store.ts
@@ -1,0 +1,53 @@
+import { useSyncExternalStore } from "react";
+
+type Alert = { level: string; msg: string };
+interface State {
+  connected: boolean;
+  positions: any[];
+  orders: any[];
+  risk: any;
+  alerts: Alert[];
+  prices: Record<string, number>;
+}
+
+const state: State = {
+  connected: false,
+  positions: [],
+  orders: [],
+  risk: null,
+  alerts: [],
+  prices: {},
+};
+
+const listeners = new Set<() => void>();
+
+function setState(partial: Partial<State>) {
+  Object.assign(state, partial);
+  listeners.forEach((l) => l());
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useWS() {
+  return useSyncExternalStore(subscribe, () => state.connected);
+}
+export function usePositions() {
+  return useSyncExternalStore(subscribe, () => state.positions);
+}
+export function useOrders() {
+  return useSyncExternalStore(subscribe, () => state.orders);
+}
+export function useRisk() {
+  return useSyncExternalStore(subscribe, () => state.risk);
+}
+export function useAlerts() {
+  return useSyncExternalStore(subscribe, () => state.alerts);
+}
+
+export const wsStore = {
+  setState,
+  getState: () => state,
+};

--- a/dashboard/src/lib/ws.ts
+++ b/dashboard/src/lib/ws.ts
@@ -1,0 +1,47 @@
+import { wsStore } from "./store";
+import { toast } from "sonner";
+
+export function connectWS(baseUrl: string) {
+  const url = baseUrl.replace(/^http/, "ws") + "/ws";
+  let socket: WebSocket | null = null;
+  let retry = 1000;
+
+  const connect = () => {
+    socket = new WebSocket(url);
+    socket.onopen = () => {
+      wsStore.setState({ connected: true });
+      retry = 1000;
+    };
+    socket.onclose = () => {
+      wsStore.setState({ connected: false });
+      setTimeout(connect, retry);
+      retry = Math.min(retry * 2, 10000);
+    };
+    socket.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        switch (msg.type) {
+          case "positions":
+            wsStore.setState({ positions: msg.items });
+            break;
+          case "orders":
+            wsStore.setState({ orders: msg.items });
+            break;
+          case "risk":
+            wsStore.setState({ risk: msg.state });
+            break;
+          case "alert":
+            toast(msg.msg);
+            wsStore.setState({ alerts: [...wsStore.getState().alerts, msg] });
+            break;
+          case "price":
+            wsStore.setState({ prices: { ...wsStore.getState().prices, [msg.symbol]: msg.last } });
+            break;
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+  };
+  connect();
+}

--- a/smoke_live.sh
+++ b/smoke_live.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE="${BASE:-http://localhost:8000}"
+pp(){ if command -v jq >/dev/null 2>&1; then jq .; else cat; fi }
+
+echo "== Broker positions =="
+curl -s "$BASE/api/v1/broker/positions" | pp
+
+echo "== Broker orders =="
+curl -s "$BASE/api/v1/broker/orders" | pp
+
+echo "== Auto execute preview =="
+curl -s -X POST "$BASE/api/v1/auto/execute" \
+  -H "content-type: application/json" \
+  -d '{"symbol":"SPY","side":"buy","entry":1,"stop":0.5,"risk_R":1,"confirm":false}' | pp
+
+echo "== Auto execute confirm =="
+curl -s -X POST "$BASE/api/v1/auto/execute" \
+  -H "content-type: application/json" \
+  -d '{"symbol":"SPY","side":"buy","entry":1,"stop":0.5,"risk_R":1,"confirm":true}' | pp || true


### PR DESCRIPTION
## Summary
- implement websocket manager and risk engine with heartbeat
- expose broker, auto-trade, and state snapshot APIs
- add dashboard websocket store with pages for positions, orders, risk, and signals
- document environment configuration and provide smoke tests

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c3a3f1320883209cb4b7c986ffa850