### PR TITLE
refactor: use standard timer types

### DIFF
--- a/hooks/use-connection-monitor.ts
+++ b/hooks/use-connection-monitor.ts
@@ -17,13 +17,16 @@ export function useConnectionMonitor() {
     retryCount: 0,
   })
 
-  const healthCheckInterval = useRef<NodeJS.Timeout | null>(null)
-  const retryTimeout = useRef<NodeJS.Timeout | null>(null)
+  const healthCheckInterval = useRef<ReturnType<typeof setInterval> | null>(null)
+  const retryTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const checkApiHealth = useCallback(async () => {
     try {
       const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), 5000) // 5 second timeout
+      const timeoutId: ReturnType<typeof setTimeout> = setTimeout(
+        () => controller.abort(),
+        5000,
+      ) // 5 second timeout
 
       const response = await fetch("/api/proxy/health", {
         method: "GET",

--- a/hooks/use-websocket.ts
+++ b/hooks/use-websocket.ts
@@ -26,7 +26,7 @@ export function useWebSocket(url: string, options: UseWebSocketOptions = {}) {
 
   const ws = useRef<WebSocket | null>(null)
   const reconnectAttempts = useRef(0)
-  const reconnectTimer = useRef<NodeJS.Timeout | null>(null)
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { onMessage, onError, onConnect, onDisconnect, reconnectInterval = 3000, maxReconnectAttempts = 5 } = options
 


### PR DESCRIPTION
## Summary
- use ReturnType-based typings for setTimeout/setInterval in WebSocket and connection monitor hooks
- annotate all timer holders for cross-environment compatibility

## Testing
- `pnpm lint` *(fails: requires ESLint configuration)*
- `pnpm run test` *(fails: missing test script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c4423939dc832086bdd770e2ddacd0