### PR TITLE
fix: guard navigator when monitoring connection

### DIFF
--- a/hooks/use-connection-monitor.ts
+++ b/hooks/use-connection-monitor.ts
@@ -11,7 +11,7 @@ interface ConnectionState {
 
 export function useConnectionMonitor() {
   const [connectionState, setConnectionState] = useState<ConnectionState>({
-    isOnline: navigator.onLine,
+    isOnline: typeof navigator !== "undefined" ? navigator.onLine : true,
     apiHealthy: false,
     lastCheck: 0,
     retryCount: 0,


### PR DESCRIPTION
## Summary
- avoid referencing `navigator` during initial render by defaulting to `true` when undefined

## Testing
- `pytest`
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c4423b878c83209ba791ff7ec5d455