### PR TITLE
Refactor services to async HTTP clients

### DIFF
--- a/app/routers/assistant.py
+++ b/app/routers/assistant.py
@@ -46,7 +46,7 @@ async def assistant_exec(req: Request):
         raise HTTPException(status_code=400, detail={"ok": False, "error": "bad_request", "detail": str(e)})
 
     try:
-        result = actions_mod.execute_action(body.op, body.args or {})
+        result = await actions_mod.execute_action(body.op, body.args or {})
     except ValidationError as ve:
         raise HTTPException(status_code=400, detail={"ok": False, "error": "validation_error", "detail": ve.errors()})
     except Exception as e:

--- a/app/services/polygon.py
+++ b/app/services/polygon.py
@@ -6,23 +6,27 @@ _API_KEY = os.getenv("POLYGON_API_KEY", "").strip()
 
 class PolygonError(RuntimeError): ...
 
-def _client() -> httpx.Client:
+
+def _client() -> httpx.AsyncClient:
+    """Return a configured async HTTP client for Polygon."""
     if not _API_KEY:
         raise PolygonError("POLYGON_API_KEY not set")
     headers = {"Authorization": f"Bearer " + _API_KEY}
-    return httpx.Client(base_url=_BASE, headers=headers, timeout=10.0)
+    return httpx.AsyncClient(base_url=_BASE, headers=headers, timeout=10.0)
 
-def get_json(path: str, params: Dict[str, Any] | None=None) -> Dict[str, Any]:
-    with _client() as c:
-        r = c.get(path, params=params or {})
+
+async def get_json(path: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    async with _client() as c:
+        r = await c.get(path, params=params or {})
     if r.status_code >= 400:
         raise PolygonError(f"HTTP {r.status_code}: {r.text[:300]}")
     return r.json()
 
-def last_quote(symbol: str) -> Dict[str, Any]:
+
+async def last_quote(symbol: str) -> Dict[str, Any]:
     """Return last trade price for symbol."""
     try:
-        js = get_json(f"/v2/last/trade/{symbol}")
+        js = await get_json(f"/v2/last/trade/{symbol}")
         price = js.get("results", {}).get("p")
         ts = js.get("results", {}).get("t")
         return {"ok": True, "symbol": symbol, "last": price, "ts": ts}

--- a/app/services/tradier_client.py
+++ b/app/services/tradier_client.py
@@ -6,7 +6,8 @@ _TOKEN = os.getenv("TRADIER_ACCESS_TOKEN", "").strip()
 
 class TradierError(RuntimeError): ...
 
-def _client() -> httpx.Client:
+
+def _client() -> httpx.AsyncClient:
     if not _BASE:
         raise TradierError("TRADIER_BASE not set")
     if not _TOKEN:
@@ -16,11 +17,12 @@ def _client() -> httpx.Client:
         "Accept": "application/json",
         "User-Agent": "ta/1.0",
     }
-    return httpx.Client(base_url=_BASE, headers=headers, timeout=12.0)
+    return httpx.AsyncClient(base_url=_BASE, headers=headers, timeout=12.0)
 
-def get(path: str, params: Dict[str, Any] | None=None) -> Dict[str, Any]:
-    with _client() as c:
-        r = c.get(path, params=params or {})
+
+async def get(path: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    async with _client() as c:
+        r = await c.get(path, params=params or {})
     if r.status_code >= 400:
         raise TradierError(f"HTTP {r.status_code}: {r.text[:400]}")
     return r.json()


### PR DESCRIPTION
## Summary
- migrate Polygon service to `httpx.AsyncClient`
- convert Tradier helpers and option lookup to async/await
- update assistant actions and router to await async services

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c457a441b48320aff4335e481875eb