### PR TITLE
refactor: standardize Tradier env token name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Continue building your app on:
 The backend reads the following environment variables:
 
 - `TRADIER_BASE` – Tradier API base URL (defaults to sandbox)
-- `TRADIER_TOKEN` – Tradier access token
+- `TRADIER_ACCESS_TOKEN` – Tradier access token
 - `POLYGON_API_KEY` – optional key for Polygon quotes
 - `DATA_MODE`
 - `WS_PING_SEC`

--- a/app/routers/diag_config.py
+++ b/app/routers/diag_config.py
@@ -9,7 +9,7 @@ def config():
     # Show which relevant env vars are set (mask values)
     keys = [
         "TRADIER_BASE", "TRADIER_ENV",
-        "TRADIER_TOKEN", "TRADIER_ACCESS_TOKEN",
+        "TRADIER_ACCESS_TOKEN",
         "POLYGON_API_KEY"
     ]
     env = {k: ("set" if os.getenv(k) else "") for k in keys}
@@ -18,9 +18,9 @@ def config():
 @router.get("/tradier")
 async def tradier(symbol: str = "SPY"):
     base = (os.getenv("TRADIER_BASE") or "https://sandbox.tradier.com").rstrip("/")
-    token = os.getenv("TRADIER_TOKEN") or os.getenv("TRADIER_ACCESS_TOKEN")
+    token = os.getenv("TRADIER_ACCESS_TOKEN")
     if not token:
-        raise HTTPException(status_code=400, detail="TRADIER token not set")
+        raise HTTPException(status_code=400, detail="TRADIER_ACCESS_TOKEN not set")
 
     url = f"{base}/v1/markets/options/expirations"
     async with httpx.AsyncClient(timeout=20.0) as client:

--- a/app/routers/options.py
+++ b/app/routers/options.py
@@ -41,7 +41,7 @@ class OptionsPickResponse(BaseModel):
     source: Optional[str] = None  # NEW: "tradier" or "polygon"
 
 # ---------- Config ----------
-TRADIER_TOKEN = os.getenv("TRADIER_TOKEN", os.getenv("TRADIER_ACCESS_TOKEN", "")).strip()
+TRADIER_ACCESS_TOKEN = os.getenv("TRADIER_ACCESS_TOKEN", "").strip()
 POLYGON_KEY = os.getenv("POLYGON_API_KEY", "").strip()
 ENV_NOTE = "delayed via Tradier Sandbox; Polygon fallback only if Tradier empty/unavailable"
 
@@ -302,10 +302,10 @@ async def options_pick(
     Fallback: Polygon reference when Tradier is unavailable or empty (unless prefer='tradier').
     """
     force_tradier = (req.prefer == "tradier")
-    if not TRADIER_TOKEN and not force_tradier:
+    if not TRADIER_ACCESS_TOKEN and not force_tradier:
         if POLYGON_KEY:
             return await _fallback_polygon(req.symbol, req.side, req.horizon, req.n)
-        raise HTTPException(status_code=400, detail="tradier_error: TRADIER_TOKEN not set")
+        raise HTTPException(status_code=400, detail="tradier_error: TRADIER_ACCESS_TOKEN not set")
 
     # Try Tradier first (or force it)
     try:

--- a/app/services/daily_fallback.py
+++ b/app/services/daily_fallback.py
@@ -4,14 +4,14 @@ import httpx, os, datetime as dt
 
 # --- Tradier daily history ---
 TRADIER_BASE = os.getenv("TRADIER_BASE", "https://sandbox.tradier.com")
-TRADIER_TOKEN = os.getenv("TRADIER_ACCESS_TOKEN")
+TRADIER_ACCESS_TOKEN = os.getenv("TRADIER_ACCESS_TOKEN")
 
 async def tradier_daily_close(symbol: str) -> Optional[float]:
-    if not TRADIER_TOKEN:
+    if not TRADIER_ACCESS_TOKEN:
         return None
     url = f"{TRADIER_BASE}/v1/markets/history"
     params = {"symbol": symbol.upper()}
-    hdrs = {"Authorization": f"Bearer {TRADIER_TOKEN}", "Accept": "application/json"}
+    hdrs = {"Authorization": f"Bearer {TRADIER_ACCESS_TOKEN}", "Accept": "application/json"}
     async with httpx.AsyncClient(timeout=10) as client:
         r = await client.get(url, params=params, headers=hdrs)
         if r.status_code != 200:

--- a/app/services/providers.py
+++ b/app/services/providers.py
@@ -4,12 +4,12 @@ import httpx
 from app.integrations.tradier import TradierClient
 
 TRADIER_BASE = os.getenv("TRADIER_BASE", "https://sandbox.tradier.com")
-TRADIER_TOKEN = os.getenv("TRADIER_ACCESS_TOKEN")
+TRADIER_ACCESS_TOKEN = os.getenv("TRADIER_ACCESS_TOKEN")
 POLYGON_KEY = os.getenv("POLYGON_API_KEY")
 APP_TZ = os.getenv("APP_TIMEZONE", "America/Chicago")
 
 _http_timeout = httpx.Timeout(20.0, connect=10.0)
-_headers_tradier = {"Authorization": f"Bearer {TRADIER_TOKEN}", "Accept": "application/json"} if TRADIER_TOKEN else {}
+_headers_tradier = {"Authorization": f"Bearer {TRADIER_ACCESS_TOKEN}", "Accept": "application/json"} if TRADIER_ACCESS_TOKEN else {}
 
 _tradier_client: Optional[TradierClient] = None
 
@@ -45,7 +45,7 @@ async def _aget_json(url: str, headers: Dict[str,str] = None, params: Dict[str,A
 # ----- Quotes (prefer Tradier; fallback Polygon daily close) -----
 async def get_last_price(symbol: str, client: Optional[TradierClient] = None) -> Optional[float]:
     # Tradier real/15-min delayed last
-    if TRADIER_TOKEN:
+    if TRADIER_ACCESS_TOKEN:
         quotes = await _tradier(client).get_quotes([symbol])
         q = quotes.get(symbol) or {}
         last = q.get("last") or q.get("close") or q.get("bid") or q.get("ask")

--- a/app/services/tradier.py
+++ b/app/services/tradier.py
@@ -3,10 +3,10 @@ from typing import Dict, Any, List, Optional
 import httpx
 
 TRADIER_BASE = os.getenv("TRADIER_BASE", "https://sandbox.tradier.com")
-TRADIER_TOKEN = os.getenv("TRADIER_ACCESS_TOKEN")
+TRADIER_ACCESS_TOKEN = os.getenv("TRADIER_ACCESS_TOKEN")
 
 HDRS = {
-    "Authorization": f"Bearer {TRADIER_TOKEN}" if TRADIER_TOKEN else "",
+    "Authorization": f"Bearer {TRADIER_ACCESS_TOKEN}" if TRADIER_ACCESS_TOKEN else "",
     "Accept": "application/json"
 }
 
@@ -62,7 +62,7 @@ def tradier_batch_option_quotes(symbols: list[str]) -> dict[str, dict]:
     if not symbols:
         return out
 
-    token = os.getenv("TRADIER_TOKEN") or os.getenv("TRADIER_ACCESS_TOKEN") or ""
+    token = os.getenv("TRADIER_ACCESS_TOKEN") or ""
     if not token:
         return out
 

--- a/tests/test_options_dependency.py
+++ b/tests/test_options_dependency.py
@@ -4,7 +4,7 @@ from app.routers import options
 
 
 def test_options_pick_injects_client(monkeypatch):
-    monkeypatch.setattr(options, "TRADIER_TOKEN", "token")
+    monkeypatch.setattr(options, "TRADIER_ACCESS_TOKEN", "token")
     class DummyClient:
         def __init__(self):
             self.closed = False

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -19,8 +19,8 @@ def test_last_quote(monkeypatch):
     monkeypatch.setattr(
         polygon,
         "_client",
-        lambda: httpx.Client(transport=transport, base_url="https://api.polygon.io"),
+        lambda: httpx.AsyncClient(transport=transport, base_url="https://api.polygon.io"),
     )
 
-    result = polygon.last_quote("AAPL")
+    result = asyncio.run(polygon.last_quote("AAPL"))
     assert result == {"ok": True, "symbol": "AAPL", "last": 123.4, "ts": 169}


### PR DESCRIPTION
## Summary
- unify Tradier access token environment variable across backend modules
- adjust diagnostics and service utilities to read `TRADIER_ACCESS_TOKEN`
- document new variable and fix related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c457a22a7c8320ac001ff75017bd60