### PR TITLE
Rename option type param for Tradier option greeks

### DIFF
--- a/app/integrations/tradier.py
+++ b/app/integrations/tradier.py
@@ -124,7 +124,7 @@ class TradierClient:
         return r.json()
 
     async def get_option_greeks(
-        self, symbol: str, expiration: str, strike: float, type: str
+        self, symbol: str, expiration: str, strike: float, option_type: str
     ) -> Dict[str, Any]:
         """Fetch greek data for a specific option contract.
 
@@ -135,7 +135,7 @@ class TradierClient:
             "symbol": symbol,
             "expiration": expiration,
             "strike": strike,
-            "type": type,
+            "type": option_type,
         }
         cid = str(uuid4())
         s = await self._session()

--- a/app/routers/options.py
+++ b/app/routers/options.py
@@ -225,7 +225,12 @@ async def _pick_from_tradier(client: TradierClient, symbol: str, side: str, hori
 
     missing_delta = [oc for oc in prelim if oc.delta is None]
     if missing_delta:
-        tasks = [tc.get_option_greeks(symbol, oc.expiration, oc.strike, oc.option_type) for oc in missing_delta]
+        tasks = [
+            tc.get_option_greeks(
+                symbol, oc.expiration, oc.strike, option_type=oc.option_type
+            )
+            for oc in missing_delta
+        ]
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for oc, res in zip(missing_delta, results):
             if isinstance(res, Exception):


### PR DESCRIPTION
## Summary
- rename `type` parameter to `option_type` in `TradierClient.get_option_greeks`
- update options router to pass `option_type` keyword argument

## Testing
- `pytest -q` *(fails: tests/test_polygon.py::test_last_quote)*
- `pytest tests/test_tradier_greeks.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c45ae31d84832092d483e7b790dd18