### PR TITLE
Align polygon test with sync client and add ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "postcss": "^8.5",
     "tailwindcss": "^4.1.9",
     "tw-animate-css": "1.3.3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "eslint": "^8.57.0"
   }
 }

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import sys, importlib, asyncio
+import sys, importlib
 import httpx
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,8 +19,8 @@ def test_last_quote(monkeypatch):
     monkeypatch.setattr(
         polygon,
         "_client",
-        lambda: httpx.AsyncClient(transport=transport, base_url="https://api.polygon.io"),
+        lambda: httpx.Client(transport=transport, base_url="https://api.polygon.io"),
     )
 
-    result = asyncio.run(polygon.last_quote("AAPL"))
+    result = polygon.last_quote("AAPL")
     assert result == {"ok": True, "symbol": "AAPL", "last": 123.4, "ts": 169}


### PR DESCRIPTION
## Summary
- align polygon test with synchronous `last_quote`
- add minimal Next.js ESLint config and dependency

## Testing
- `pytest`
- `npm run lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_b_68c46055bc7483209a92ee737ed62ffd