### PR TITLE
Improve assistant error handling and retry support

### DIFF
--- a/hooks/use-trading-api.ts
+++ b/hooks/use-trading-api.ts
@@ -85,6 +85,9 @@ export function useTradingAPI() {
   }, [])
 
   const executeAssistantAction = useCallback(async (op: string, args: any) => {
+    setIsLoading(true)
+    setError(null)
+
     try {
       const response = await fetch(`/api/proxy?path=${encodeURIComponent("/assistant/exec")}`, {
         method: "POST",
@@ -98,10 +101,14 @@ export function useTradingAPI() {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }
 
-      return await response.json()
+      const result = await response.json()
+      return result
     } catch (err) {
-      console.error("Failed to execute assistant action:", err)
-      return { ok: false, error: err instanceof Error ? err.message : "Unknown error" }
+      const errorMessage = err instanceof Error ? err.message : "Unknown error occurred"
+      setError(errorMessage)
+      throw err
+    } finally {
+      setIsLoading(false)
     }
   }, [])
 

--- a/hooks/use-websocket.ts
+++ b/hooks/use-websocket.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useState, useCallback } from "react"
+import { toast } from "sonner"
 
 interface WebSocketMessage {
   type: string
@@ -119,12 +120,17 @@ export function useWebSocket(url: string, options: UseWebSocketOptions = {}) {
   }, [])
 
   const sendMessage = useCallback((message: any) => {
-    if (ws.current?.readyState === WebSocket.OPEN) {
-      ws.current.send(JSON.stringify(message))
-      return true
+    try {
+      if (ws.current?.readyState === WebSocket.OPEN) {
+        ws.current.send(JSON.stringify(message))
+        return true
+      }
+      throw new Error("WebSocket not connected")
+    } catch (error) {
+      toast.error("Failed to send message")
+      console.error("[v0] WebSocket send error:", error)
+      return false
     }
-    console.warn("[v0] WebSocket not connected, message not sent")
-    return false
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- wrap WebSocket sendMessage in try/catch and show toast on failure
- propagate executeAssistantAction errors via hook state and throw to caller
- add retryable UI and toasts when assistant message sending fails

## Testing
- `npm test` (fails: Missing script)
- `npx vitest run`
- `npm run lint` (fails: ESLint must be installed)


------
https://chatgpt.com/codex/tasks/task_b_68c4854515b08320a83ce1953a144d5f