### PR TITLE
feat: introduce assistant conversation hook

### DIFF
--- a/dashboard/tests/useAssistantConversation.test.ts
+++ b/dashboard/tests/useAssistantConversation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest"
+import { act } from "react-dom/test-utils"
+import { createRoot } from "react-dom/client"
+import React from "react"
+import { useAssistantConversation } from "../../hooks/useAssistantConversation"
+
+function mockScroll(ref: any) {
+  Object.defineProperty(ref, "scrollHeight", { value: 100, writable: true })
+  Object.defineProperty(ref, "scrollTop", { value: 0, writable: true })
+}
+
+describe("useAssistantConversation", () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  test("handles message flow with rationale and auto-scroll", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ content: "response", rationale: "because" }),
+    }) as any
+
+    const result: { current: ReturnType<typeof useAssistantConversation> } = { current: null as any }
+    function Test() {
+      result.current = useAssistantConversation()
+      return null
+    }
+    const container = document.createElement("div")
+    const root = createRoot(container)
+    act(() => {
+      root.render(React.createElement(Test))
+    })
+    const div = document.createElement("div")
+    mockScroll(div)
+    result.current.scrollRef.current = div
+
+    await act(async () => {
+      await result.current.sendMessage("hello")
+    })
+
+    const msgs = result.current.messages
+    expect(msgs.at(-3)?.content).toBe("hello")
+    expect(msgs.at(-2)?.content).toBe("response")
+    expect(msgs.at(-1)?.content).toBe("because")
+    expect(result.current.isTyping).toBe(false)
+    expect(result.current.scrollRef.current?.scrollTop).toBe(100)
+  })
+
+  test("handles API errors", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 }) as any
+
+    const result2: { current: ReturnType<typeof useAssistantConversation> } = { current: null as any }
+    function Test2() {
+      result2.current = useAssistantConversation()
+      return null
+    }
+    const container2 = document.createElement("div")
+    const root2 = createRoot(container2)
+    act(() => {
+      root2.render(React.createElement(Test2))
+    })
+
+    await act(async () => {
+      await result2.current.sendMessage("hi")
+    })
+
+    const last = result2.current.messages.at(-1)
+    expect(last?.type).toBe("system")
+    expect(last?.content).toContain("Error")
+    expect(result2.current.isTyping).toBe(false)
+  })
+})
+

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node',
+    environment: 'jsdom',
     globals: true,
   },
 });

--- a/hooks/useAssistantConversation.ts
+++ b/hooks/useAssistantConversation.ts
@@ -1,0 +1,113 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+
+export interface AssistantMessage {
+  id: string
+  type: "user" | "assistant" | "system"
+  content: string
+  timestamp: Date
+  actionType?: "buy" | "sell" | "hold" | "alert"
+  symbol?: string
+  confidence?: number
+}
+
+interface ApiResponse {
+  content: string
+  rationale?: string
+}
+
+export function useAssistantConversation() {
+  const [messages, setMessages] = useState<AssistantMessage[]>([
+    {
+      id: "1",
+      type: "system",
+      content: "Trading Assistant initialized. Monitoring market conditions...",
+      timestamp: new Date(),
+    },
+    {
+      id: "2",
+      type: "assistant",
+      content:
+        "Good morning! I'm analyzing current market conditions. SPY is showing bullish momentum with volume confirmation. Consider watching for pullback entries.",
+      timestamp: new Date(),
+      actionType: "alert",
+      symbol: "SPY",
+      confidence: 75,
+    },
+  ])
+  const [isTyping, setIsTyping] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [messages])
+
+  const addMessage = (message: AssistantMessage) => {
+    setMessages((prev) => [...prev, message])
+  }
+
+  const sendMessage = async (input: string) => {
+    if (!input.trim()) return
+
+    const userMessage: AssistantMessage = {
+      id: Date.now().toString(),
+      type: "user",
+      content: input,
+      timestamp: new Date(),
+    }
+
+    addMessage(userMessage)
+    setIsTyping(true)
+
+    try {
+      const response = await fetch("/api/assistant", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message: input }),
+      })
+
+      if (!response.ok) {
+        throw new Error(`API request failed: ${response.status}`)
+      }
+
+      const data: ApiResponse = await response.json()
+
+      const assistantMessage: AssistantMessage = {
+        id: (Date.now() + 1).toString(),
+        type: "assistant",
+        content: data.content,
+        timestamp: new Date(),
+      }
+
+      addMessage(assistantMessage)
+
+      if (data.rationale) {
+        const rationaleMessage: AssistantMessage = {
+          id: (Date.now() + 2).toString(),
+          type: "system",
+          content: data.rationale,
+          timestamp: new Date(),
+        }
+        addMessage(rationaleMessage)
+      }
+    } catch (err: any) {
+      const errorMessage: AssistantMessage = {
+        id: (Date.now() + 3).toString(),
+        type: "system",
+        content: `Error: ${err.message}`,
+        timestamp: new Date(),
+      }
+      addMessage(errorMessage)
+    } finally {
+      setIsTyping(false)
+    }
+  }
+
+  return { messages, isTyping, sendMessage, scrollRef, addMessage }
+}
+


### PR DESCRIPTION
## Summary
- create `useAssistantConversation` hook to manage conversation, rationale, and auto-scroll
- refactor `AITradingAssistant` to use the hook and focus on UI
- add tests for conversation hook and switch vitest to jsdom

## Testing
- `pnpm vitest run --config dashboard/vitest.config.ts`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c4853e346c8320997244625b0f8247