### PR TITLE
feat: centralize assistant conversation state

### DIFF
--- a/hooks/useAssistantConversation.ts
+++ b/hooks/useAssistantConversation.ts
@@ -1,0 +1,39 @@
+import { useState } from "react"
+import type { AssistantMessage } from "@/lib/types"
+
+export function useAssistantConversation() {
+  const [messages, setMessages] = useState<AssistantMessage[]>([
+    {
+      id: "1",
+      type: "system",
+      content: "Trading Assistant initialized. Monitoring market conditions...",
+      timestamp: new Date(),
+    },
+    {
+      id: "2",
+      type: "assistant",
+      content:
+        "Good morning! I'm analyzing current market conditions. SPY is showing bullish momentum with volume confirmation. Consider watching for pullback entries.",
+      timestamp: new Date(),
+      actionType: "alert",
+      symbol: "SPY",
+      confidence: 75,
+    },
+  ])
+  const [isTyping, setIsTyping] = useState(false)
+  const [retryMessage, setRetryMessage] = useState<AssistantMessage | null>(null)
+
+  const addSignalMessage = (message: AssistantMessage) => {
+    setMessages((prev) => [...prev, message])
+  }
+
+  return {
+    messages,
+    setMessages,
+    isTyping,
+    setIsTyping,
+    retryMessage,
+    setRetryMessage,
+    addSignalMessage,
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,9 @@
+export interface AssistantMessage {
+  id: string
+  type: "user" | "assistant" | "system"
+  content: string
+  timestamp: Date
+  actionType?: "buy" | "sell" | "hold" | "alert"
+  symbol?: string
+  confidence?: number
+}


### PR DESCRIPTION
## Summary
- move AssistantMessage to shared lib/types
- add useAssistantConversation hook for chat state and signal messages
- integrate hook and wrap message sending with useCallback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c4884abb5c8320945e1020ffce9eb1