### PR TITLE
refactor: centralize options helpers

### DIFF
--- a/app/assistant/actions.py
+++ b/app/assistant/actions.py
@@ -7,7 +7,7 @@ import inspect
 
 # Import your domain functions directly (no HTTP roundtrips)
 from app.services.options_live_tradier import (
-    pick_live_contracts_tradier,
+    pick_live_contracts,
     fetch_expirations as _fetch_expirations,
     fetch_chain as _fetch_chain,
 )
@@ -33,7 +33,7 @@ class OptionsChainArgs(BaseModel):
 
 # ---------- Exec handlers ----------
 async def _op_options_pick(args: OptionsPickArgs) -> Dict[str, Any]:
-    return await pick_live_contracts_tradier(args.symbol, args.side, args.horizon, args.n)
+    return await pick_live_contracts(args.symbol, args.side, args.horizon, args.n)
 
 
 async def _op_options_expirations(args: OptionsExpirationsArgs) -> Dict[str, Any]:

--- a/app/assistant/actions.py.broken-backup
+++ b/app/assistant/actions.py.broken-backup
@@ -5,7 +5,7 @@ from datetime import date
 
 # Import your domain functions directly (no HTTP roundtrips)
 from app.services.options_live_tradier import (
-    pick_live_contracts_tradier,
+    pick_live_contracts,
     fetch_expirations as _fetch_expirations,
     fetch_chain as _fetch_chain,
 )
@@ -31,7 +31,7 @@ class OptionsChainArgs(BaseModel):
 
 # ---------- Exec handlers ----------
 def _op_options_pick(args: OptionsPickArgs) -> Dict[str, Any]:
-    return pick_live_contracts_tradier(args.symbol, args.side, args.horizon, args.n)
+    return pick_live_contracts(args.symbol, args.side, args.horizon, args.n)
 
 def _op_options_expirations(args: OptionsExpirationsArgs) -> Dict[str, Any]:
     exps = _fetch_expirations(args.symbol)

--- a/app/services/options_common.py
+++ b/app/services/options_common.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Iterable, List, Optional, Tuple, Literal
+from dateutil.tz import UTC
+
+# Shared literals used by options helpers
+Horizon = Literal["intra", "day", "week"]
+
+
+def _today_utc() -> date:
+    """Return today's date in UTC."""
+    return datetime.now(tz=UTC).date()
+
+
+def expiration_window(horizon: Horizon) -> Tuple[int, int]:
+    """Return (min_dte, max_dte) window for an expiration horizon."""
+    if horizon in ("intra", "day"):
+        return 0, 2
+    return 3, 10
+
+
+def choose_expiration_from_list(exps: Iterable[date], horizon: Horizon) -> date:
+    """Select an expiration from a list based on horizon."""
+    today = _today_utc()
+    min_dte, max_dte = expiration_window(horizon)
+    exps_sorted = sorted(exps)
+    window = {today + timedelta(days=d) for d in range(min_dte, max_dte + 1)}
+    for e in exps_sorted:
+        if e in window:
+            return e
+    for e in exps_sorted:
+        if e >= today:
+            return e
+    return exps_sorted[-1]
+
+
+def nearest_strike_indices(strikes: List[float], spot: float, take: int) -> List[int]:
+    """Return indices of strikes closest to spot."""
+    indexed = list(enumerate(strikes))
+    ranked = sorted(indexed, key=lambda it: (abs(it[1] - spot), it[1]))
+    return [i for i, _ in ranked[:take]]
+
+
+def format_quote(
+    bid: Optional[float],
+    ask: Optional[float],
+    last: Optional[float] = None,
+) -> Tuple[Optional[float], Optional[float], Optional[float], Optional[float]]:
+    """Normalize option quote fields and compute mark/spread."""
+    mark: Optional[float] = None
+    if bid is not None and ask is not None:
+        try:
+            mark = (float(bid) + float(ask)) / 2.0
+        except Exception:
+            mark = None
+    elif last is not None:
+        try:
+            mark = float(last)
+        except Exception:
+            mark = None
+    spread_pct: Optional[float] = None
+    try:
+        if mark and bid is not None and ask is not None and mark > 0:
+            spread_pct = (float(ask) - float(bid)) / float(mark)
+    except Exception:
+        spread_pct = None
+    return (
+        float(bid) if bid is not None else None,
+        float(ask) if ask is not None else None,
+        mark,
+        spread_pct,
+    )
+

--- a/app/services/options_live.py
+++ b/app/services/options_live.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from typing import Dict, Any, List, Literal, Tuple
-from dateutil.tz import UTC
 from app.services.polygon import get_json, PolygonError
+from .options_common import (
+    _today_utc,
+    expiration_window,
+    nearest_strike_indices,
+    format_quote,
+)
 
 Side = Literal["long_call","long_put","short_call","short_put"]
 Horizon = Literal["intra","day","week"]
-
-def _today_utc() -> date:
-    return datetime.now(tz=UTC).date()
 
 def _is_weekend(d: date) -> bool:
     return d.weekday() >= 5
@@ -46,11 +48,7 @@ async def _contracts_exist(ticker: str, exp: date, cp: Literal["call","put"]) ->
 async def choose_expiration(ticker: str, horizon: Horizon, cp: Literal["call","put"]) -> date:
     # Target window by horizon
     start = _next_weekday(_today_utc())
-    if horizon in ("intra","day"):
-        # aim 0-2 DTE
-        min_dte, max_dte = 0, 2
-    else:  # week
-        min_dte, max_dte = 3, 10
+    min_dte, max_dte = expiration_window(horizon)
 
     # Probe forward up to 14 days; prefer first date within window; otherwise first available
     first_available: date | None = None
@@ -78,14 +76,8 @@ async def fetch_contracts_for_exp(ticker: str, exp: date, cp: Literal["call","pu
     })
     return res.get("results") or []
 
-def _nearest_indices(strikes: List[float], spot: float, take: int) -> List[int]:
-    # return indices of strikes closest to spot (ties resolved by natural order)
-    indexed = list(enumerate(strikes))
-    ranked = sorted(indexed, key=lambda it: (abs(it[1]-spot), it[1]))
-    return [i for i,_ in ranked[:take]]
-
 async def _recent_quote(opt_symbol: str) -> Tuple[float | None, float | None, float | None]:
-    # returns (bid, ask, mark) using most recent quote
+    # returns (bid, ask, last) using most recent quote
     q = await get_json(
         f"/v3/quotes/options/{opt_symbol}", {"limit": 1, "sort": "timestamp", "order": "desc"}
     )
@@ -97,15 +89,11 @@ async def _recent_quote(opt_symbol: str) -> Tuple[float | None, float | None, fl
     bid = r0.get("bid_price") or r0.get("bidPrice") or r0.get("bp")
     ask = r0.get("ask_price") or r0.get("askPrice") or r0.get("ap")
     last = r0.get("last_price") or r0.get("price") or r0.get("lp")
-    mark = None
-    if bid is not None and ask is not None:
-        try:
-            mark = (float(bid) + float(ask)) / 2.0
-        except Exception:
-            mark = None
-    return (float(bid) if bid is not None else None,
-            float(ask) if ask is not None else None,
-            float(mark) if mark is not None else (float(last) if last is not None else None))
+    return (
+        float(bid) if bid is not None else None,
+        float(ask) if ask is not None else None,
+        float(last) if last is not None else None,
+    )
 
 async def pick_live_contracts(ticker: str, side: Side, horizon: Horizon, n: int = 5) -> Dict[str, Any]:
     cp = "call" if "call" in side else "put"
@@ -117,20 +105,15 @@ async def pick_live_contracts(ticker: str, side: Side, horizon: Horizon, n: int 
 
     # Pull strikes and pick the n closest to spot
     strikes = [float(c.get("strike_price", 0.0)) for c in contracts]
-    idxs = _nearest_indices(strikes, spot, n)
+    idxs = nearest_strike_indices(strikes, spot, n)
 
     # Compose picks (and fetch quotes for those n contracts)
     picks: List[Dict[str, Any]] = []
     for i in idxs:
         c = contracts[i]
         sym = c.get("ticker") or c.get("contract") or c.get("symbol")
-        bid, ask, mark = await _recent_quote(sym)
-        ask_f = float(ask) if ask is not None else None
-        bid_f = float(bid) if bid is not None else None
-        mark_f = float(mark) if mark is not None else None
-        spread_pct = None
-        if ask_f is not None and bid_f is not None and mark_f and mark_f > 0:
-            spread_pct = (ask_f - bid_f) / mark_f
+        bid, ask, last = await _recent_quote(sym)
+        bid_f, ask_f, mark_f, spread_pct = format_quote(bid, ask, last)
         picks.append({
             "symbol": sym,
             "expiration": exp.isoformat(),

--- a/app/services/options_live_tradier.py
+++ b/app/services/options_live_tradier.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
-from datetime import date, datetime, timedelta
+from datetime import date
 from typing import Dict, Any, List, Literal
-from dateutil.tz import UTC
 from app.services.tradier_client import get, TradierError
+from .options_common import (
+    choose_expiration_from_list,
+    nearest_strike_indices,
+    format_quote,
+)
 
 Side = Literal["long_call","long_put","short_call","short_put"]
 Horizon = Literal["intra","day","week"]
-
-def _today_utc() -> date:
-    return datetime.now(tz=UTC).date()
 
 def _as_list(x):
     if x is None:
@@ -53,25 +54,7 @@ async def choose_expiration(ticker: str, horizon: Horizon) -> date:
     exps = await fetch_expirations(ticker)
     if not exps:
         raise TradierError(f"No expirations for {ticker}")
-    today = _today_utc()
-    # horizon targeting (all delayed, so this is "nearest reasonable")
-    if horizon in ("intra","day"):
-        # prefer same-day if available, else next 1-2 days
-        window = [0,1,2]
-    else:  # week
-        window = [3,4,5,6,7,8,9,10]
-    # pick first exp that is today+delta and exists
-    for d in window:
-        target = today + timedelta(days=d)
-        for e in exps:
-            if e == target:
-                return e
-    # fallback: first expiration in the future
-    for e in exps:
-        if e >= today:
-            return e
-    # otherwise last
-    return exps[-1]
+    return choose_expiration_from_list(exps, horizon)
 
 # ---------- Chains & Quotes ----------
 async def fetch_chain(ticker: str, exp: date) -> List[Dict[str, Any]]:
@@ -99,7 +82,7 @@ async def fetch_option_quotes(symbols: List[str]) -> Dict[str, Dict[str, Any]]:
     return out
 
 # ---------- Pick closest-to-ATM N for a side ----------
-async def pick_live_contracts_tradier(ticker: str, side: Side, horizon: Horizon, n: int = 5) -> Dict[str, Any]:
+async def pick_live_contracts(ticker: str, side: Side, horizon: Horizon, n: int = 5) -> Dict[str, Any]:
     cp = "call" if "call" in side else "put"
     spot = await fetch_spot(ticker)
     exp = await choose_expiration(ticker, horizon)
@@ -107,54 +90,45 @@ async def pick_live_contracts_tradier(ticker: str, side: Side, horizon: Horizon,
     if not chain:
         raise TradierError("No chain returned")
 
-    # filter by call/put
     leg = [o for o in chain if (o.get("option_type") or "").lower() == cp]
     if not leg:
         raise TradierError("No contracts for requested side")
 
-    # sort by |strike - spot|
-    def _strike(o): 
-        try: return float(o.get("strike"))
-        except: return float("inf")
-    leg_sorted = sorted(leg, key=lambda o: abs(_strike(o) - spot))
-    picks_raw = leg_sorted[:max(1, min(n, 10))]
+    strikes: List[float] = []
+    for o in leg:
+        try:
+            strikes.append(float(o.get("strike")))
+        except Exception:
+            strikes.append(float("inf"))
+    idxs = nearest_strike_indices(strikes, spot, max(1, min(n, 10)))
+    picks_raw = [leg[i] for i in idxs]
 
-    # fetch quotes for these option symbols to get bid/ask/mark
     syms = [o.get("symbol") for o in picks_raw if o.get("symbol")]
     qmap = await fetch_option_quotes(syms)
 
     picks = []
     for o in picks_raw:
         sym = o.get("symbol")
-        k = _strike(o)
+        k = o.get("strike")
+        try:
+            k = float(k) if k not in (None, "na") else None
+        except Exception:
+            k = None
         q = qmap.get(sym, {})
         bid = q.get("bid") if q.get("bid") not in (None, "na") else None
         ask = q.get("ask") if q.get("ask") not in (None, "na") else None
         last = q.get("last") if q.get("last") not in (None, "na") else None
-        mark = None
-        try:
-            if bid is not None and ask is not None:
-                mark = (float(bid) + float(ask)) / 2.0
-            elif last is not None:
-                mark = float(last)
-        except Exception:
-            mark = None
-        spread_pct = None
-        try:
-            if bid is not None and ask is not None and mark and float(mark) > 0:
-                spread_pct = (float(ask) - float(bid)) / float(mark)
-        except Exception:
-            spread_pct = None
+        bid_f, ask_f, mark_f, spread_pct = format_quote(bid, ask, last)
 
         picks.append({
             "symbol": sym,
             "expiration": exp.isoformat(),
-            "strike": float(k),
+            "strike": k,
             "option_type": cp,
-            "bid": float(bid) if bid is not None else None,
-            "ask": float(ask) if ask is not None else None,
-            "mark": float(mark) if mark is not None else None,
-            "spread_pct": float(spread_pct) if spread_pct is not None else None,
+            "bid": bid_f,
+            "ask": ask_f,
+            "mark": mark_f,
+            "spread_pct": spread_pct,
             "open_interest": o.get("open_interest"),
             "volume": o.get("volume"),
         })


### PR DESCRIPTION
## Summary
- add `options_common` helper module for expiration logic, strike filtering, quote formatting
- refactor Polygon and Tradier live options services to import shared helpers and expose `pick_live_contracts`
- update assistant actions to use new Tradier API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c49003e9e08320891cfcfcffb15c0a