### PR TITLE
refactor: centralize options side and horizon types

### DIFF
--- a/app/assistant/actions.py
+++ b/app/assistant/actions.py
@@ -11,10 +11,9 @@ from app.services.options_live_tradier import (
     fetch_expirations as _fetch_expirations,
     fetch_chain as _fetch_chain,
 )
+from app.services.options_common import Side, Horizon
 
 # ---------- Request models ----------
-Side = Literal["long_call","long_put","short_call","short_put"]
-Horizon = Literal["intra","day","week"]
 
 class OptionsPickArgs(BaseModel):
     symbol: str = Field(..., description="Underlying ticker, e.g. SPY, AAPL")

--- a/app/assistant/actions.py.broken-backup
+++ b/app/assistant/actions.py.broken-backup
@@ -9,10 +9,9 @@ from app.services.options_live_tradier import (
     fetch_expirations as _fetch_expirations,
     fetch_chain as _fetch_chain,
 )
+from app.services.options_common import Side, Horizon
 
 # ---------- Request models ----------
-Side = Literal["long_call","long_put","short_call","short_put"]
-Horizon = Literal["intra","day","week"]
 
 class OptionsPickArgs(BaseModel):
     symbol: str = Field(..., description="Underlying ticker, e.g. SPY, AAPL")

--- a/app/services/options_common.py
+++ b/app/services/options_common.py
@@ -5,6 +5,7 @@ from typing import Iterable, List, Optional, Tuple, Literal
 from dateutil.tz import UTC
 
 # Shared literals used by options helpers
+Side = Literal["long_call", "long_put", "short_call", "short_put"]
 Horizon = Literal["intra", "day", "week"]
 
 

--- a/app/services/options_live.py
+++ b/app/services/options_live.py
@@ -7,10 +7,9 @@ from .options_common import (
     expiration_window,
     nearest_strike_indices,
     format_quote,
+    Side,
+    Horizon,
 )
-
-Side = Literal["long_call","long_put","short_call","short_put"]
-Horizon = Literal["intra","day","week"]
 
 def _is_weekend(d: date) -> bool:
     return d.weekday() >= 5

--- a/app/services/options_live_tradier.py
+++ b/app/services/options_live_tradier.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 from datetime import date
-from typing import Dict, Any, List, Literal
+from typing import Dict, Any, List
 from app.services.tradier_client import get, TradierError
 from .options_common import (
     choose_expiration_from_list,
     nearest_strike_indices,
     format_quote,
+    Side,
+    Horizon,
 )
-
-Side = Literal["long_call","long_put","short_call","short_put"]
-Horizon = Literal["intra","day","week"]
 
 def _as_list(x):
     if x is None:


### PR DESCRIPTION
## Summary
- add shared `Side` literal to `options_common`
- use shared `Side` and `Horizon` in options services
- align assistant actions to import option type aliases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c493234eec8320b6650d4914589f39