### PR TITLE
Centralize Tradier settings usage and add tests

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -1,31 +1,36 @@
+import os
 from pydantic import BaseModel
-from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Optional
 
-class Settings(BaseSettings):
+
+class Settings(BaseModel):
     # Core
-    APP_NAME: str = "Trading Assistant API"
-    APP_ENV: str = "prod"  # prod|dev|test
-    APP_TIMEZONE: str = "America/Chicago"
+    APP_NAME: str = os.getenv("APP_NAME", "Trading Assistant API")
+    APP_ENV: str = os.getenv("APP_ENV", "prod")  # prod|dev|test
+    APP_TIMEZONE: str = os.getenv("APP_TIMEZONE", "America/Chicago")
 
     # External services (optional at startup; warn if missing)
-    POLYGON_API_KEY: Optional[str] = None
-    CHATDATA_API_KEY: Optional[str] = None
-    CHATDATA_CHATBOT_ID: Optional[str] = None
+    POLYGON_API_KEY: Optional[str] = os.getenv("POLYGON_API_KEY")
+    CHATDATA_API_KEY: Optional[str] = os.getenv("CHATDATA_API_KEY")
+    CHATDATA_CHATBOT_ID: Optional[str] = os.getenv("CHATDATA_CHATBOT_ID")
 
     # Broker (optional for now)
-    TRADIER_ACCESS_TOKEN: Optional[str] = None
-    TRADIER_ACCOUNT_ID: Optional[str] = None
-    TRADIER_ENV: str = "sandbox"
-    TRADIER_BASE: str = "https://sandbox.tradier.com"
+    TRADIER_ACCESS_TOKEN: Optional[str] = os.getenv("TRADIER_ACCESS_TOKEN")
+    TRADIER_ACCOUNT_ID: Optional[str] = os.getenv("TRADIER_ACCOUNT_ID")
+    TRADIER_ENV: str = os.getenv("TRADIER_ENV", "sandbox")
+    TRADIER_BASE: str = os.getenv("TRADIER_BASE", "https://sandbox.tradier.com")
+
+    @property
+    def tradier_base_url(self) -> str:
+        """Return the Tradier API base URL without a trailing slash."""
+        return (self.TRADIER_BASE or "").rstrip("/")
 
     # Storage / misc
-    DATABASE_URL: Optional[str] = None
-    FMP_API_KEY: Optional[str] = None
-    FINNHUB_API_KEY: Optional[str] = None
-    ALERT_POLL_SEC: int = 15
+    DATABASE_URL: Optional[str] = os.getenv("DATABASE_URL")
+    FMP_API_KEY: Optional[str] = os.getenv("FMP_API_KEY")
+    FINNHUB_API_KEY: Optional[str] = os.getenv("FINNHUB_API_KEY")
+    ALERT_POLL_SEC: int = int(os.getenv("ALERT_POLL_SEC", "15"))
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
 settings = Settings()
 

--- a/app/services/tradier_client.py
+++ b/app/services/tradier_client.py
@@ -1,23 +1,24 @@
-import os, httpx
+import httpx
 from typing import Any, Dict
 
-_BASE = os.getenv("TRADIER_BASE", "").rstrip("/")
-_TOKEN = os.getenv("TRADIER_ACCESS_TOKEN", "").strip()
+from app.core.settings import settings
 
 class TradierError(RuntimeError): ...
 
 
 def _client() -> httpx.AsyncClient:
-    if not _BASE:
+    base = settings.tradier_base_url
+    token = settings.TRADIER_ACCESS_TOKEN or ""
+    if not base:
         raise TradierError("TRADIER_BASE not set")
-    if not _TOKEN:
+    if not token:
         raise TradierError("TRADIER_ACCESS_TOKEN not set")
     headers = {
-        "Authorization": f"Bearer {_TOKEN}",
+        "Authorization": f"Bearer {token}",
         "Accept": "application/json",
         "User-Agent": "ta/1.0",
     }
-    return httpx.AsyncClient(base_url=_BASE, headers=headers, timeout=12.0)
+    return httpx.AsyncClient(base_url=base, headers=headers, timeout=12.0)
 
 
 async def get(path: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:

--- a/tests/test_tradier_settings.py
+++ b/tests/test_tradier_settings.py
@@ -1,0 +1,47 @@
+import asyncio
+import pytest
+import asyncio
+import pytest
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from app.core.settings import settings
+from app.services import tradier_client, options_picker, tradier
+from app.routers import broker_tradier
+from fastapi import HTTPException
+
+
+def test_tradier_client_missing_token(monkeypatch):
+    import asyncio
+    monkeypatch.setattr(settings, 'TRADIER_ACCESS_TOKEN', None)
+    with pytest.raises(tradier_client.TradierError):
+        asyncio.run(tradier_client.get('/test'))
+
+
+def test_options_picker_missing_token(monkeypatch):
+    import asyncio
+    monkeypatch.setattr(settings, 'TRADIER_ACCESS_TOKEN', None)
+    result = asyncio.run(options_picker.pick_options('AAPL', 'call', 0, 1, 1))
+    assert result['ok'] is False
+
+
+def test_broker_headers_missing_token(monkeypatch):
+    monkeypatch.setattr(settings, 'TRADIER_ACCESS_TOKEN', None)
+    with pytest.raises(HTTPException):
+        broker_tradier._headers()
+
+
+def test_account_overview_missing_account(monkeypatch):
+    import asyncio
+    monkeypatch.setattr(settings, 'TRADIER_ACCESS_TOKEN', 'token')
+    monkeypatch.setattr(settings, 'TRADIER_ACCOUNT_ID', None)
+    with pytest.raises(HTTPException):
+        asyncio.run(broker_tradier.account_overview())
+
+
+def test_tradier_batch_quotes_missing_token(monkeypatch):
+    monkeypatch.setattr(settings, 'TRADIER_ACCESS_TOKEN', None)
+    assert tradier.tradier_batch_option_quotes(['AAPL']) == {}


### PR DESCRIPTION
## Summary
- Expose Tradier credentials and base URL through `Settings`
- Update Tradier clients and routers to read from central settings
- Add tests ensuring missing Tradier config is handled gracefully

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c493260c048320850403c1eadc8bf0