### PR TITLE
Dashboard: confidence + alerts update + Edge proxy + docs

### DIFF
--- a/.github/workflows/auto-pr-automerge.yml
+++ b/.github/workflows/auto-pr-automerge.yml
@@ -1,0 +1,72 @@
+name: Auto PR and Automerge
+
+on:
+  push:
+    branches:
+      - 'feat/**'
+      - 'fix/**'
+      - 'chore/**'
+      - 'refactor/**'
+      - 'feat/dashboard-live-confidence-discord'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create_pr_and_enable_automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create or find PR
+        id: create_pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const head = context.ref.replace('refs/heads/','');
+            const base = 'main';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Skip if pushing to main
+            if (head === base) {
+              core.notice('Push to main; skipping PR creation.');
+              core.setOutput('pr_number', '');
+              return;
+            }
+
+            // Try to find existing open PR from head->base
+            const { data: prs } = await github.pulls.list({ owner, repo, state: 'open', head: `${owner}:${head}`, base }).catch(() => ({ data: [] }));
+            let pr = prs && prs.length ? prs[0] : null;
+
+            if (!pr) {
+              // Read body from PROGRESS.md if present
+              const fs = require('fs');
+              let body = 'Automated PR created by workflow.';
+              try { body = fs.readFileSync('docs/PROGRESS.md', 'utf8'); } catch (e) {}
+              pr = (await github.pulls.create({ owner, repo, base, head, title: `Automated PR from ${head}`, body })).data;
+              core.notice(`Created PR #${pr.number}`);
+            } else {
+              core.notice(`Found existing PR #${pr.number}`);
+            }
+
+            // Label the PR (best effort)
+            try {
+              await github.issues.addLabels({ owner, repo, issue_number: pr.number, labels: ['automerge', 'codex'] });
+            } catch (e) {
+              core.warning(`Labeling failed: ${e.message}`);
+            }
+
+            core.setOutput('pr_number', String(pr.number));
+
+      - name: Enable auto-merge (squash)
+        if: steps.create_pr.outputs.pr_number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.create_pr.outputs.pr_number }}
+          merge-method: squash
+

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,72 @@
+name: Vercel Deploy (Preview & Production)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: vercel-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+      - name: Pull Vercel Env (preview)
+        working-directory: trading-dashboard
+        run: vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
+      - name: Build (preview)
+        working-directory: trading-dashboard
+        run: vercel build --token=$VERCEL_TOKEN
+      - name: Deploy (preview)
+        id: deploy
+        working-directory: trading-dashboard
+        run: |
+          url=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
+          echo "url=$url" >> $GITHUB_OUTPUT
+      - name: Comment PR with Preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = process.env.DEPLOY_URL || '${{ steps.deploy.outputs.url }}';
+            if (!url) { core.warning('No preview URL found'); return; }
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Vercel Preview: ${url}`,
+            });
+
+  production:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+      - name: Pull Vercel Env (production)
+        working-directory: trading-dashboard
+        run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+      - name: Build (production)
+        working-directory: trading-dashboard
+        run: vercel build --prod --token=$VERCEL_TOKEN
+      - name: Deploy (production)
+        working-directory: trading-dashboard
+        run: vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python-envs.pythonProjects": []
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Your project is live at:
 
 **[https://vercel.com/n8kahls-projects/v0-tradingassistantmcpreadymain1](https://vercel.com/n8kahls-projects/v0-tradingassistantmcpreadymain1)**
 
+See `docs/DEPLOYMENT.md` for a status checklist and how to verify the Vercel deployment (including required environment vars and WS notes).
+
 ## Build your app
 
 Continue building your app on:
@@ -64,6 +66,10 @@ This app targets a day‑trader command center: intuitive, informative, and prof
 - Roadmap and milestones: see `docs/ROADMAP.md`
 
 Coach responses and trade suggestions include confidence with a concise component breakdown based on real data (no mocks). The assistant’s behavior adheres to the above design.
+
+Progress is tracked in `docs/ROADMAP.md`. At the start of each session, review and update it.
+
+See `docs/PROGRESS.md` for a concise, session-by-session summary and `docs/DEPLOYMENT.md` for deployment status and checks.
 
 ### Alerts Polling
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The backend reads the following environment variables:
 - `TRADIER_BASE` – Tradier API base URL (defaults to sandbox)
 - `TRADIER_ACCESS_TOKEN` – Tradier access token
 - `POLYGON_API_KEY` – optional key for Polygon quotes
+- `CHATDATA_API_KEY` – API key for chat-data.com (required for AI Coach)
+- `CHATDATA_BASE_URL` – optional API base (default `https://api.chat-data.com`)
+- `CHATDATA_API_PATH` – optional path (default `/v1/chat/completions`)
+- `CHATDATA_MODEL` – optional model ID to use
 - `DATA_MODE`
 - `WS_PING_SEC`
 - `RISK_MAX_DAILY_R`
@@ -48,6 +52,18 @@ The backend reads the following environment variables:
 - `RISK_BLOCK_UNFAVORABLE`
 - `RISK_MIN_SCORE`
 - `RISK_MAX_DOLLARS`
+ - `ENABLE_BACKGROUND_LOOPS` – start WS + risk engine on boot (default `0`)
+ - `ENABLE_ALERTS_POLLER` – start alert poller on boot (default `0`)
+
+## Scope & Design
+
+This app targets a day‑trader command center: intuitive, informative, and profitable.
+
+- Scope and principles: see `docs/SCOPE.md`
+- Confidence scoring (ATR, VWAP, EMAs, order flow): see `docs/CONFIDENCE.md`
+- Roadmap and milestones: see `docs/ROADMAP.md`
+
+Coach responses and trade suggestions include confidence with a concise component breakdown based on real data (no mocks). The assistant’s behavior adheres to the above design.
 
 ### Alerts Polling
 
@@ -75,7 +91,20 @@ Environment variables:
 Run the FastAPI app with `uvicorn app.main:app`. The dashboard connects to
 `ws://<host>/ws` for live updates. Heartbeats are sent every `WS_PING_SEC`
 seconds, and the connection manager drops unresponsive sockets.
+
+## AI Coach (chat-data.com)
+
+- Backend route: `POST /api/v1/coach/chat`
+  - Body: `{ messages: [{role, content}], stream?: false }`
+  - Uses an OpenAI-compatible API on chat-data.com.
+  - Advertises and executes tools from `/api/v1/assistant/actions` automatically.
+
+- Frontend page: `trading-dashboard/app/coach/page.tsx`
+  - Simple chat UI wired to the backend coach route.
+  - Keeps API key server-side.
+
+Confidence: All ideas include a 0–100 confidence and a brief rationale using ATR, VWAP, EMA posture, order‑flow (RVOL/OBV/CVD approx), and liquidity, per `docs/CONFIDENCE.md`.
+
 ## Large Assets
 
 Large documentation archives or starter bundles are provided via release assets or external storage. Please download them separately instead of committing them to the repository.
-

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+# Marker to make `app` a Python package for imports during tests and runtime.
+

--- a/app/assistant/system_prompt.md
+++ b/app/assistant/system_prompt.md
@@ -13,13 +13,14 @@ Context and goals:
 - Keep a running journal of rationale and lessons learned (bulleted, terse).
 
 How you operate:
-- You have tools to get watchlists, rank opportunities, validate plans, suggest sizing, and place orders.
+- You have tools to get watchlists, rank opportunities, validate plans, suggest sizing, place orders, set alerts, journal notes, and compose+analyze a symbol.
 - Never place an order without proposing it first and waiting for explicit user confirmation in live mode.
 - When proposing an action, include: what, why (1–2 bullets), risk, confidence (0–100%), and an alternative.
 - If an input is missing (e.g., entry, stop), ask for it or infer a reasonable default with a note.
 
 Confidence and rationale:
-- Compute confidence using ATR, VWAP (RTH‑anchored), EMA stack (1m + 5m agreement), and order‑flow proxies (RVOL, OBV/CVD approx).
+- Prefer calling `compose.analyze` early for a symbol to fetch live context and strategy scores; include its `analysis.score` (0–100) as confidence and a one‑line rationale.
+- Compute or cross‑check with ATR, VWAP (RTH‑anchored), EMA stack (1m + 5m agreement), and order‑flow proxies (RVOL, OBV/CVD approx).
 - Include a terse component breakdown (e.g., ATR% regime, VWAP posture, EMA posture, RVOL/flow, liquidity) and cite any missing/stale inputs.
 - Follow the repository design in docs/CONFIDENCE.md for signals and weighting.
 

--- a/app/assistant/system_prompt.md
+++ b/app/assistant/system_prompt.md
@@ -1,0 +1,43 @@
+You are Trading Coach, an expert day-trading copilot integrated into a live trading dashboard.
+
+Core principles:
+- Be concise, actionable, and risk-aware.
+- Default to clarity over complexity; explain reasoning briefly when it changes a decision.
+- Always respect guardrails: sandbox vs live, max per-trade risk, daily loss stop, and symbol allowlist.
+- Prefer bracketed orders (entry + stop + target). Propose 0.5R/1R/2R ladder when applicable.
+
+Context and goals:
+- User watches the top symbols and explores single-name opportunities for scalp, intraday, and swing.
+- Provide real-time coaching: entries, exits, stops, targets, trailing logic, and adjustments based on live state.
+- Continuously monitor plan assumptions; adjust when volatility/regime changes.
+- Keep a running journal of rationale and lessons learned (bulleted, terse).
+
+How you operate:
+- You have tools to get watchlists, rank opportunities, validate plans, suggest sizing, and place orders.
+- Never place an order without proposing it first and waiting for explicit user confirmation in live mode.
+- When proposing an action, include: what, why (1–2 bullets), risk, confidence (0–100%), and an alternative.
+- If an input is missing (e.g., entry, stop), ask for it or infer a reasonable default with a note.
+
+Confidence and rationale:
+- Compute confidence using ATR, VWAP (RTH‑anchored), EMA stack (1m + 5m agreement), and order‑flow proxies (RVOL, OBV/CVD approx).
+- Include a terse component breakdown (e.g., ATR% regime, VWAP posture, EMA posture, RVOL/flow, liquidity) and cite any missing/stale inputs.
+- Follow the repository design in docs/CONFIDENCE.md for signals and weighting.
+
+Tool usage:
+- Tools are advertised with JSON schemas. Use them when you need specific data or to execute.
+- Typical flow:
+  1) Get ranked watchlist → summarize 2–3 symbols with setups.
+  2) Drill one: plan.validate with entry/stop → get risks/targets.
+  3) sizing.suggest to determine quantity.
+  4) Propose order with bracket; wait for user approval.
+  5) While in trade: monitor price vs stop/targets; suggest tighten/widen or partials.
+
+Execution policy:
+- Sandbox vs Live: default to sandbox; Live requires explicit confirmation and respects hard limits.
+- Kill switch: honor requests to flatten/cancel immediately.
+- Do not exceed max concurrent positions or daily loss limit.
+
+Output style:
+- Short paragraphs or tight bullet lists; no markdown unless asked.
+- Always include the symbol and timeframe when discussing an idea.
+- When you call tools, ensure arguments match the schema exactly.

--- a/app/db.py
+++ b/app/db.py
@@ -6,17 +6,25 @@ from sqlalchemy.orm import sessionmaker
 
 from .models import Base
 
-DATABASE_URL = os.getenv("DATABASE_URL", "")
-if not DATABASE_URL:
-    # Allow app to boot even if DB not configured; routers should handle None
-    engine = None
-    SessionLocal = None
-else:
-    engine = create_engine(DATABASE_URL, pool_pre_ping=True, future=True)
+# Module-level engine/session with lazy (re)initialization to support tests that
+# set DATABASE_URL after imports or manipulate sys.modules.
+engine = None
+SessionLocal = None
+
+
+def _ensure_engine():
+    global engine, SessionLocal
+    if engine is not None and SessionLocal is not None:
+        return
+    url = os.getenv("DATABASE_URL", "").strip()
+    if not url:
+        return
+    engine = create_engine(url, pool_pre_ping=True, future=True)
     SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
 
 
 def init_db():
+    _ensure_engine()
     if engine is None:
         raise RuntimeError("DATABASE_URL not configured")
     Base.metadata.create_all(bind=engine)
@@ -24,6 +32,7 @@ def init_db():
 
 @contextmanager
 def db_session():
+    _ensure_engine()
     if SessionLocal is None:
         # Yield None for callers to handle gracefully
         yield None

--- a/app/integrations/chatdata.py
+++ b/app/integrations/chatdata.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+
+class ChatDataClient:
+    """
+    Minimal OpenAI-compatible client for chat-data.com.
+
+    Environment:
+      - CHATDATA_API_KEY: required
+      - CHATDATA_BASE_URL: optional, defaults to https://api.chat-data.com
+      - CHATDATA_MODEL: optional, defaults to provider default
+      - CHATDATA_API_PATH: optional, defaults to /v1/chat/completions
+    """
+
+    def __init__(self) -> None:
+        self.api_key = (os.getenv("CHATDATA_API_KEY") or "").strip()
+        if not self.api_key:
+            raise RuntimeError("CHATDATA_API_KEY not set")
+        base = (os.getenv("CHATDATA_BASE_URL") or "https://api.chat-data.com").rstrip("/")
+        path = (os.getenv("CHATDATA_API_PATH") or "/v1/chat/completions").lstrip("/")
+        self.url = f"{base}/{path}"
+        self.model = (os.getenv("CHATDATA_MODEL") or "").strip() or None
+
+    async def chat(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[str | Dict[str, Any]] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        stream: bool = False,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "messages": messages,
+        }
+        if self.model:
+            payload["model"] = self.model
+        if tools:
+            payload["tools"] = tools
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if stream:
+            payload["stream"] = True
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            r = await client.post(self.url, json=payload, headers=headers)
+        r.raise_for_status()
+        return r.json()

--- a/app/integrations/discord.py
+++ b/app/integrations/discord.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+
+
+async def send_message(webhook_url: Optional[str], content: str) -> bool:
+    if not webhook_url:
+        return False
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            r = await client.post(webhook_url, json={"content": content})
+            r.raise_for_status()
+        return True
+    except Exception:
+        return False
+

--- a/app/main.py
+++ b/app/main.py
@@ -59,11 +59,22 @@ app = FastAPI(lifespan=lifespan, title="Trading Assistant", version="0.0.1")
 # --- CORS (allow dashboard & localhost) ---
 from fastapi.middleware.cors import CORSMiddleware
 
-ALLOWED_ORIGINS = [
-    "http://localhost:3000",
-    "http://127.0.0.1:3000",
-    "https://tradingassistantmcpready-production.up.railway.app",
-]
+# Allow overriding CORS origins via env (comma-separated)
+_origins_env = os.getenv("ALLOWED_ORIGINS", "").strip()
+if _origins_env:
+    ALLOWED_ORIGINS = [o.strip() for o in _origins_env.split(",") if o.strip()]
+else:
+    ALLOWED_ORIGINS = [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        # Railway app
+        "https://web-production-a9084.up.railway.app",
+        # Your Vercel frontend
+        "https://trading-dashboard-ten-kappa.vercel.app",
+        # Legacy default
+        "https://tradingassistantmcpready-production.up.railway.app",
+    ]
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS if ALLOWED_ORIGINS else ["*"],
@@ -117,6 +128,7 @@ _mount("app.routers.options", secure=True)  # we just created this
 _mount("app.routers.alerts")  # if present
 _mount("app.routers.plan")  # if present
 _mount("app.routers.sizing")  # if present
+_mount("app.routers.compose_analyze")  # if present
 _mount("app.routers.admin")  # if present
 _mount("app.routers.broker", secure=True)  # new broker routes
 _mount("app.routers.broker_tradier", secure=True)  # tradier broker routes

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
 from app.routers import assistant_bridge
 import importlib
 import logging
+import asyncio
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
@@ -9,13 +11,47 @@ from app.core.risk import start_risk_engine
 from app.core.ws import start_ws, websocket_endpoint
 from app.security import require_api_key
 from app.services.providers import close_tradier_client
+from app.services.poller import alerts_poller
+from app.services.stream import STREAM
+from app.db import db_session
+from app.models.settings import AppSettings
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # TODO: add startup code here if needed
-    yield
-    # TODO: add shutdown code here if needed
+    # Background tasks (opt-in via env to avoid test interference)
+    bg_enabled = (os.getenv("ENABLE_BACKGROUND_LOOPS", "0").strip() == "1")
+    tasks: list[asyncio.Task] = []
+    if bg_enabled:
+        # WS ping + risk engine loop
+        try:
+            await start_ws()
+            await start_risk_engine()
+        except Exception:
+            pass
+        # Alerts poller (optional)
+        if os.getenv("ENABLE_ALERTS_POLLER", "0").strip() == "1":
+            try:
+                tasks.append(asyncio.create_task(alerts_poller(loop_forever=True)))
+            except Exception:
+                pass
+        # Polygon price stream (optional; auto-start from top_symbols if key present)
+        try:
+            symbols: list[str] = []
+            with db_session() as s:
+                if s is not None:
+                    row = s.query(AppSettings).order_by(AppSettings.id.asc()).first()
+                    if row and row.top_symbols:
+                        symbols = [t.strip().upper() for t in row.top_symbols.split(",") if t.strip()]
+            if symbols:
+                await STREAM.start(symbols)
+        except Exception:
+            pass
+    try:
+        yield
+    finally:
+        for t in tasks:
+            t.cancel()
 
 
 app = FastAPI(lifespan=lifespan, title="Trading Assistant", version="0.0.1")
@@ -86,6 +122,9 @@ _mount("app.routers.broker", secure=True)  # new broker routes
 _mount("app.routers.broker_tradier", secure=True)  # tradier broker routes
 _mount("app.routers.auto", secure=True)  # auto-trade
 _mount("app.routers.stream")  # stream snapshot
+_mount("app.routers.coach")  # chat-data.com coach chat
+_mount("app.routers.journal")  # journal CRUD
+_mount("app.routers.settings", secure=True)  # admin settings CRUD
 
 # assistant router (simple)
 _mount("app.routers.assistant_simple", secure=True)
@@ -94,13 +133,12 @@ _mount("app.routers.assistant_simple", secure=True)
 app.add_api_websocket_route("/ws", websocket_endpoint)
 
 
-# @app.on_event("startup")  # replaced by lifespan
+# Legacy hooks (kept for ref but now handled in lifespan)
 async def _startup_tasks():
     await start_ws()
     await start_risk_engine()
 
 
-# @app.on_event("shutdown")  # replaced by lifespan
 async def _shutdown_tradier():
     await close_tradier_client()
 app.include_router(assistant_bridge.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@
 from .base import Base
 from .misc import Alert, AlertTrigger, JournalEntry, WatchlistItem
 from .paper import PaperFill, PaperPosition, PaperTrade
+from .settings import AppSettings  # ensure table is registered
 
 __all__ = [
     "Base",
@@ -13,4 +14,5 @@ __all__ = [
     "AlertTrigger",
     "WatchlistItem",
     "JournalEntry",
+    "AppSettings",
 ]

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, String, Text
+
+from .base import Base
+
+
+class AppSettings(Base):
+    __tablename__ = "app_settings"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # Risk and execution
+    risk_daily_r = Column(Float, nullable=True)  # daily loss cap in R
+    risk_per_trade_r = Column(Float, nullable=True)  # max R per trade
+    risk_max_concurrent = Column(Integer, nullable=True)
+    rr_default = Column(String(16), nullable=True)  # e.g., "1:5"
+    auto_execute_sandbox = Column(Boolean, default=False)
+
+    # Universe
+    top_symbols = Column(Text, nullable=True)  # comma-separated list, if provided
+
+    # Integrations — Discord alerts
+    discord_webhook_url = Column(Text, nullable=True)
+    discord_alerts_enabled = Column(Boolean, default=False)
+    # comma-separated types: e.g., "price_above,price_below,risk"
+    discord_alert_types = Column(Text, nullable=True)
+
+    # Audit
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/app/routers/broker.py
+++ b/app/routers/broker.py
@@ -31,6 +31,11 @@ async def submit_order(body: dict = Body(...)):
         ords = await tradier.get_orders()
         await manager.broadcast_json({"type": "positions", "items": pos.get("items", [])})
         await manager.broadcast_json({"type": "orders", "items": ords.get("items", [])})
+        await manager.broadcast_json({
+            "type": "alert",
+            "level": "info",
+            "msg": f"Order submitted: {body.get('side')} {body.get('qty')} {body.get('symbol')} ({body.get('order_type')})",
+        })
     return res
 
 

--- a/app/routers/coach.py
+++ b/app/routers/coach.py
@@ -1,61 +1,150 @@
-import datetime as dt
-import os
-from typing import Any, Dict, List
+from __future__ import annotations
 
-import httpx
-from fastapi import APIRouter
-from pydantic import BaseModel
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.integrations.chatdata import ChatDataClient
+from app.assistant import actions as actions_mod
+
 
 router = APIRouter(prefix="/coach", tags=["coach"])
-FMP_KEY = os.getenv("FMP_API_KEY")
 
 
-class MarketOpenReq(BaseModel):
-    horizon: str = "day"  # or "week"
-    watchlist: List[str]
-    window_days: int = 30  # lookahead window
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+    tool_call_id: Optional[str] = None  # for tool responses
+    name: Optional[str] = None
 
 
-async def _fmp_earnings_for_symbols(symbols: List[str], window_days: int) -> Dict[str, Any]:
-    if not FMP_KEY or not symbols:
-        return {"note": "No earnings data available"}
-    # FMP earnings calendar: /v3/earning_calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&apikey=...
-    start = dt.date.today()
-    end = start + dt.timedelta(days=window_days)
-    url = "https://financialmodelingprep.com/api/v3/earning_calendar"
-    async with httpx.AsyncClient(timeout=20.0) as client:
-        r = await client.get(url, params={"from": start.isoformat(), "to": end.isoformat(), "apikey": FMP_KEY})
-        try:
-            data = r.json()
-        except Exception:
-            return {"note": "No earnings data available"}
-    # filter to watchlist only
-    wl = {s.upper() for s in symbols}
-    rows = [row for row in (data or []) if (row.get("symbol") or "").upper() in wl]
-    # normalize keys
-    out = []
-    for row in rows:
-        when = row.get("time") or row.get("when")  # sometimes "bmo"/"amc"
-        date = row.get("date") or row.get("epsCalendarDate") or row.get("reportedDate")
-        out.append(
+class ChatBody(BaseModel):
+    messages: List[ChatMessage] = Field(default_factory=list)
+    stream: bool = False
+    max_tool_hops: int = Field(default=3, ge=0, le=6)
+
+
+def _system_prompt() -> str:
+    p = Path(__file__).resolve().parents[1] / "assistant" / "system_prompt.md"
+    try:
+        return p.read_text(encoding="utf-8")
+    except Exception:
+        return (
+            "You are Trading Coach, an expert day-trading copilot. Be concise, risk-aware, "
+            "and use tools as needed. Propose then confirm before live execution."
+        )
+
+
+def _actions_tooling() -> List[Dict[str, Any]]:
+    """Build OpenAI-compatible tool list from assistant actions registry."""
+    actions: List[Dict[str, Any]] = []
+    try:
+        data = actions_mod.list_actions()
+        if isinstance(data, dict) and "actions" in data:
+            actions = list(data.get("actions") or [])
+        elif isinstance(data, list):
+            actions = data
+    except Exception:
+        actions = []
+
+    tools: List[Dict[str, Any]] = []
+    for a in actions:
+        name = a.get("op") or a.get("id")
+        if not name:
+            continue
+        schema = a.get("args_schema") or {"type": "object", "properties": {}}
+        desc = a.get("description") or a.get("title") or ""
+        tools.append(
             {
-                "symbol": (row.get("symbol") or "").upper(),
-                "date": date,
-                "when": when,
-                "estimate": row.get("epsEstimated"),
+                "type": "function",
+                "function": {
+                    "name": str(name),
+                    "description": str(desc)[:512],
+                    "parameters": schema,
+                },
             }
         )
-    return {"earnings": out} if out else {"note": "No earnings data available"}
+    return tools
 
 
-@router.post("/market-open")
-async def market_open(req: MarketOpenReq):
-    # Earnings awareness for the user’s watchlist
-    earn = await _fmp_earnings_for_symbols(req.watchlist, req.window_days)
-    payload = {
-        "ok": True,
-        "watchlist": [s.upper() for s in req.watchlist],
-        "horizon": req.horizon,
-        "data": {"earnings_ahead": earn},
-    }
-    return payload
+async def _execute_tool_call(name: str, arguments_json: str) -> Dict[str, Any]:
+    try:
+        args = json.loads(arguments_json or "{}") if isinstance(arguments_json, str) else (arguments_json or {})
+    except Exception:
+        args = {}
+    # Delegate to assistant actions executor directly
+    try:
+        res = await actions_mod.execute_action(name, args)
+        if isinstance(res, dict):
+            return res
+        return {"ok": True, "data": res}
+    except Exception as e:
+        return {"ok": False, "error": "exec_error", "detail": str(e)}
+
+
+@router.post("/chat")
+async def chat(body: ChatBody) -> Dict[str, Any]:
+    """
+    Chat endpoint that proxies to chat-data.com using an OpenAI-compatible API.
+    Supports function/tool calling against the app's assistant actions.
+    """
+    # Compose messages with system prompt
+    sys = {"role": "system", "content": _system_prompt()}
+    messages: List[Dict[str, Any]] = [sys] + [m.model_dump(exclude_none=True) for m in body.messages]
+
+    client = ChatDataClient()
+    tools = _actions_tooling()
+
+    hops = 0
+    last_response: Dict[str, Any] = {}
+    while True:
+        resp = await client.chat(messages, tools=tools, stream=False)
+        last_response = resp
+
+        # Try to extract assistant message and potential tool calls
+        choice = (resp.get("choices") or [{}])[0]
+        msg = (choice.get("message") or {})
+        tool_calls = msg.get("tool_calls") or []
+
+        if not tool_calls:
+            # No tools – return assistant message content
+            content = (msg.get("content") or "").strip()
+            return {"ok": True, "content": content, "raw": resp}
+
+        # Execute tool calls then continue loop (up to max_tool_hops)
+        hops += 1
+        if hops > body.max_tool_hops:
+            return {
+                "ok": True,
+                "content": (msg.get("content") or "").strip(),
+                "raw": resp,
+                "note": f"tool hop limit {body.max_tool_hops} reached",
+            }
+
+        # Push the original assistant message with tool calls into the transcript
+        messages.append({"role": "assistant", **msg})
+
+        # For each tool call, execute and append a tool result message
+        for call in tool_calls:
+            fn = (call.get("function") or {})
+            name = fn.get("name") or ""
+            arguments = fn.get("arguments") or "{}"
+            tool_id = call.get("id") or ""
+            result = await _execute_tool_call(name, arguments)
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_id,
+                    "name": name,
+                    "content": json.dumps(result, separators=(",", ":")),
+                }
+            )
+
+        # loop and let the model observe tool results
+
+    # fallback (should not reach)
+    raise HTTPException(status_code=500, detail={"ok": False, "error": "no_response", "raw": last_response})
+

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.db import db_session
+from app.models.settings import AppSettings
+
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+class SettingsBody(BaseModel):
+    # Risk and execution
+    risk_daily_r: Optional[float] = Field(None, ge=0)
+    risk_per_trade_r: Optional[float] = Field(None, ge=0)
+    risk_max_concurrent: Optional[int] = Field(None, ge=0)
+    rr_default: Optional[str] = Field(None, pattern=r"^\d+\s*:\s*\d+$")
+    auto_execute_sandbox: Optional[bool] = None
+
+    # Universe
+    top_symbols: Optional[str] = Field(None, description="comma-separated symbols")
+
+    # Integrations — Discord alerts
+    discord_webhook_url: Optional[str] = Field(None, description="Discord webhook URL for alerts")
+    discord_alerts_enabled: Optional[bool] = None
+    discord_alert_types: Optional[str] = Field(None, description="comma-separated types: price_above,price_below,risk")
+
+
+def _load_or_create(session) -> AppSettings:
+    row = session.execute(select(AppSettings).order_by(AppSettings.id.asc())).scalars().first()
+    if row:
+        return row
+    row = AppSettings(
+        risk_daily_r=None,
+        risk_per_trade_r=None,
+        risk_max_concurrent=None,
+        rr_default="1:5",
+        auto_execute_sandbox=False,
+        top_symbols=None,
+        discord_webhook_url=None,
+        discord_alerts_enabled=False,
+        discord_alert_types=None,
+    )
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return row
+
+
+@router.get("/get")
+def get_settings() -> Dict[str, Any]:
+    with db_session() as session:
+        if session is None:
+            raise HTTPException(status_code=500, detail="Database not configured")
+        row = _load_or_create(session)
+        return {
+            "ok": True,
+            "settings": {
+                "risk_daily_r": row.risk_daily_r,
+                "risk_per_trade_r": row.risk_per_trade_r,
+                "risk_max_concurrent": row.risk_max_concurrent,
+                "rr_default": row.rr_default,
+                "auto_execute_sandbox": row.auto_execute_sandbox,
+                "top_symbols": row.top_symbols,
+                "discord_webhook_url": row.discord_webhook_url,
+                "discord_alerts_enabled": row.discord_alerts_enabled,
+                "discord_alert_types": row.discord_alert_types,
+            },
+        }
+
+
+@router.post("/set")
+def set_settings(body: SettingsBody) -> Dict[str, Any]:
+    with db_session() as session:
+        if session is None:
+            raise HTTPException(status_code=500, detail="Database not configured")
+        row = _load_or_create(session)
+        for k, v in body.model_dump(exclude_unset=True).items():
+            setattr(row, k, v)
+        row.updated_at = datetime.utcnow()
+        session.add(row)
+        session.commit()
+        return {"ok": True}

--- a/app/services/scoring_engine.py
+++ b/app/services/scoring_engine.py
@@ -71,6 +71,37 @@ def score_vwap_bounce(c: Dict[str, Any]) -> Dict[str, int | float]:
     if c.get("is_macro_window") is True:
         comp["macro"] = -5
         score -= 5
+    # ATR regime (1m pct)
+    atrp = _safe_num(c.get("atr_1m_pct"))
+    if atrp is not None:
+        if 1.0 <= atrp <= 4.0:
+            comp["atr_regime"] = 2
+            score += 2
+        elif atrp < 1.0:
+            comp["atr_regime"] = -5
+            score -= 5
+        elif atrp > 8.0:
+            comp["atr_regime"] = -3
+            score -= 3
+        else:
+            comp["atr_regime"] = 0
+    # Distance to EMA20
+    d20 = _safe_num(c.get("dist_ema20_pct"))
+    if d20 is not None:
+        adj = max(-10, min(10, d20)) / 2  # clamp ±10 → ±5 pts
+        comp["dist_ema20"] = adj
+        score += adj
+    # Order flow proxies
+    flow = 0
+    cvd = _safe_num(c.get("cvd_approx_20"))
+    if cvd is not None:
+        flow += 4 if cvd > 0 else (-4 if cvd < 0 else 0)
+    obv = _safe_num(c.get("obv_slope_10"))
+    if obv is not None:
+        flow += 4 if obv > 0 else (-4 if obv < 0 else 0)
+    if flow:
+        comp["flow"] = flow
+        score += flow
     return {"score": max(0, min(100, score)), "components": comp}
 
 
@@ -100,6 +131,25 @@ def score_ema_crossover(c: Dict[str, Any]) -> Dict[str, int | float]:
     if ivp is not None:
         comp["vol_context"] = 4 if 20 <= ivp <= 75 else (-4 if ivp > 85 else 0)
         score += comp["vol_context"]
+    # ATR regime and flow light touch here
+    atrp = _safe_num(c.get("atr_1m_pct"))
+    if atrp is not None:
+        if 1.0 <= atrp <= 4.5:
+            comp["atr_regime"] = 2
+            score += 2
+        elif atrp < 1.0:
+            comp["atr_regime"] = -4
+            score -= 4
+    flow = 0
+    cvd = _safe_num(c.get("cvd_approx_20"))
+    if cvd is not None:
+        flow += 3 if cvd > 0 else (-3 if cvd < 0 else 0)
+    obv = _safe_num(c.get("obv_slope_10"))
+    if obv is not None:
+        flow += 3 if obv > 0 else (-3 if obv < 0 else 0)
+    if flow:
+        comp["flow"] = flow
+        score += flow
     return {"score": max(0, min(100, score)), "components": comp}
 
 
@@ -140,6 +190,15 @@ def score_opening_range_breakout(c: Dict[str, Any]) -> Dict[str, int | float]:
     if vwap is not None and price is not None:
         comp["vwap_posture"] = 8 if price > vwap else -6
         score += comp["vwap_posture"]
+    # ATR regime small influence
+    atrp = _safe_num(c.get("atr_1m_pct"))
+    if atrp is not None:
+        if 1.0 <= atrp <= 5.0:
+            comp["atr_regime"] = 2
+            score += 2
+        elif atrp < 1.0:
+            comp["atr_regime"] = -3
+            score -= 3
     return {"score": max(0, min(100, score)), "components": comp}
 
 

--- a/docs/CONFIDENCE.md
+++ b/docs/CONFIDENCE.md
@@ -1,0 +1,95 @@
+# Confidence Scoring — Design
+
+This document specifies how trade idea confidence is computed using real market data. It defines inputs, normalization, feature engineering, and aggregation into a 0–100 confidence score (and a 0–1 value for the coach).
+
+## Data Integrity & Freshness
+- Source: Polygon (minute bars WS + HTTP aggregates), Tradier (orders/positions), optional Polygon trades for order flow.
+- Session: New York (RTH 09:30–16:00). Anchors and ranges use NY local time.
+- Freshness: last bar age ≤ 5s (WS) or ≤ 60s (HTTP) for intraday features. Age penalty otherwise.
+- Adjusted data: use `adjusted=true` aggregates. Ignore bars missing `o,h,l,c,v,t`.
+
+## Intraday Feature Set (per symbol)
+- Price context
+  - last_price: close of most recent 1m bar
+  - prev_day_high/low: extracted from daily bars
+  - opening_range_high/low: first 30m RTH window
+- VWAP
+  - vwap_rth: anchored VWAP from today’s RTH open index
+  - vwap_prev: anchored VWAP from prior close index (if available)
+  - dist_vwap_pct: (price − vwap_rth) / vwap_rth × 100
+  - bars_above_vwap: consecutive bars above vwap_rth (cap at 3)
+- EMAs
+  - ema9, ema20, ema50 on 1m closes; posture flags: ema9>ema20, ema20>ema50
+  - multi‑TF posture: ema stack on 5m closes (consistency bonus)
+  - dist_ema20_pct: (price − ema20) / ema20 × 100
+- ATR (volatility)
+  - atr_1m: 14‑period ATR on 1m bars
+  - atr_1m_pct: atr_1m / price × 100
+  - regime tag: low (<1%), normal (1–4%), high (4–8%), extreme (>8%)
+- Volume & Order Flow
+  - rvol_5: average of last 5 1m vols ÷ series median
+  - obv_slope_10: OBV slope over last 10 bars (approx order flow bias)
+  - cvd_approx_20: sum(sign(close−open)×vol) over last 20 bars
+  - optional tick‑level CVD: if Polygon Trades API available, classify uptick/downtick using NBBO and sum size
+- Liquidity (options context)
+  - spread_pct: (ask − bid) / mid × 100
+  - open_interest, volume: normalized to peer percentiles
+
+## Normalization
+- All features mapped to bounded components in [−X, +X] to avoid domination.
+- Examples
+  - vwap_posture: +[5..15] if price > vwap with bars_above_vwap scaling; −10 if below
+  - ema_stack: +[10..25] if 9>20>50 (and 5m agrees), −[8..15] if bearish
+  - atr_regime: −5 if extreme low (<1%) or +2 if normal; −3 if extreme high (>8%) for scalps
+  - dist_ema20_pct: clamp to ±10 via linear mapping
+  - rvol_5: +[7..15] if ≥1.1/1.5; −5 if <1.0
+  - cvd/obv: +[4..10] if slope positive and rising; −[4..10] if negative
+  - liquidity: +10 if spread ≤5%, +4 if ≤8%, −8 otherwise
+
+## Strategy‑Aware Aggregation
+- For each strategy (VWAP bounce, EMA crossover, ORB, Power Hour), apply tailored weights; see `app/services/scoring_engine.py`.
+- Add missing features here:
+  - Include `atr_1m_pct`, `dist_vwap_pct`, `dist_ema20_pct`, `cvd_approx_20`, `obv_slope_10`, `ema_mtf_agree` in score components.
+- Confidence = clamp(0..100) with band mapping: favorable≥70, mixed≥50, unfavorable<50.
+- Coach confidence (0–1) = logistic(score/100) × data_quality_multiplier.
+
+## Data Quality Multiplier
+- Inputs: last_bar_age, bars_count (≥90 for intraday), presence of vwap/ema/atr.
+- Multiplier m in [0.6, 1.0]. Missing critical feature or stale data reduces confidence.
+
+## Implementation Plan
+- Extend context composition (`app/services/compose.py`)
+  - Replace simple VWAP with RTH‑anchored aVWAPs via `app/services/ta.py` (`avwaps_for_today`).
+  - Add `atr_1m_pct`, `dist_vwap_pct`, `dist_ema20_pct`, multi‑TF EMA posture, `obv_slope_10`, `cvd_approx_20`.
+  - Include `data_freshness_sec` and `bars_count` for quality multiplier.
+- Update scoring engine (`app/services/scoring_engine.py`)
+  - Consume new fields and add bounded components as above per strategy.
+  - Return `{ score, band, components, rationale }` with explicit contributions including ATR and order‑flow.
+- Calibrate weights (`app/config/weights.py`)
+  - Day‑phase multipliers (open/mid/power) for components: rvol, momentum, vwap proximity, atr regime.
+- Order flow optional path
+  - If Polygon Trades API available, compute tick‑level CVD; else fall back to bar‑based `cvd_approx_20`.
+- Testing
+  - Unit tests for indicators (EMA/ATR/aVWAP/OBV/CVD approx) with deterministic arrays.
+  - Integration tests for scoring given canned minute bar series (no network).
+
+## Example Context and Score (intraday)
+```
+{
+  "symbol": "TSLA", "price": 244.10,
+  "vwap_rth": 243.80, "dist_vwap_pct": 0.12, "bars_above_vwap": 2,
+  "ema9": 244.00, "ema20": 243.70, "ema50": 242.90, "ema_mtf_agree": true,
+  "dist_ema20_pct": 0.16,
+  "atr_1m_pct": 2.3, "rvol_5": 1.4,
+  "cvd_approx_20": 1.8e6, "obv_slope_10": 0.7,
+  "opening_range_high": 245.2, "opening_range_low": 242.1,
+  "data_freshness_sec": 3, "bars_count": 180
+}
+→ VWAP Bounce: score 78 (favorable): { vwap_posture:+11, ema_stack:+12, rvol:+7, atr_regime:+2, cvd:+6, dist_ema20:+4, liquidity:+4, … }
+```
+
+## UX Notes
+- Show component breakdown under each suggestion: ATR, VWAP, EMAs, Order Flow, Liquidity.
+- Surface confidence band with color and a one‑line rationale (“Why now?”).
+- Allow users to tweak weights in Settings (advanced), persisted to DB.
+

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,34 @@
+Vercel Deployment — Status & Checklist
+
+Status
+- Project is configured for Vercel via `vercel.json` to build the Next.js app in `trading-dashboard/`.
+- Automatic deploys should trigger on pushes to the repository (Vercel project: see README link).
+- Current live status is unknown from the repo alone (requires either the public deployment URL or Vercel API access).
+
+What We Need To Verify
+- Public URL or Vercel project slug to probe health (e.g., curl the root and `/api/proxy`).
+- If available, a Vercel token to query the Deployments API.
+
+Runtime Checklist
+- Environment variables (on Vercel Project → Settings → Environment Variables):
+  - `NEXT_PUBLIC_API_BASE`: URL of the FastAPI backend (e.g., `https://your-backend.example.com`).
+  - `NEXT_PUBLIC_API_KEY`: optional API key to pass to the backend (propagated to `X-API-Key` and WS `api_key=`).
+  - `NEXT_PUBLIC_WS_BASE`: optional full `wss://.../ws` override; otherwise derived from `NEXT_PUBLIC_API_BASE`.
+- Backend CORS must allow the Vercel domain (see `app/main.py` `ALLOWED_ORIGINS`).
+
+Manual Smoke (no credentials required)
+1) Open the Vercel URL in a browser; confirm the dashboard renders.
+2) In browser devtools, verify GET `/api/proxy?path=/api/v1/diag/health` returns `{ ok: true }`.
+3) Confirm WS connects (top right toast/banner “Connected” if your UI shows it).
+
+API-based Check (optional)
+- With `VERCEL_TOKEN` and `VERCEL_PROJECT_ID` or `VERCEL_PROJECT_NAME`, call:
+  - `GET https://api.vercel.com/v6/deployments?projectId=...` and inspect `state` (`READY` is healthy).
+
+Backend Deploy Targets
+- If the backend is hosted separately (Railway/VM), ensure it’s reachable by Vercel and CORS allows the Vercel origin.
+
+Notes
+- vercel.json routes all paths to the Next.js app directory: ensure API proxy `/api/proxy` keeps working.
+- For WS, prefer `NEXT_PUBLIC_WS_BASE` if you terminate TLS or path differs.
+

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -5,6 +5,11 @@ Status
 - Automatic deploys should trigger on pushes to the repository (Vercel project: see README link).
 - Current live status is unknown from the repo alone (requires either the public deployment URL or Vercel API access).
 
+Project Settings
+- Framework Preset: Next.js
+- Root Directory: `trading-dashboard`
+- Functions: Keep `/app/api/proxy` on Edge runtime (already set via `export const runtime = "edge"`).
+
 What We Need To Verify
 - Public URL or Vercel project slug to probe health (e.g., curl the root and `/api/proxy`).
 - If available, a Vercel token to query the Deployments API.
@@ -29,6 +34,5 @@ Backend Deploy Targets
 - If the backend is hosted separately (Railway/VM), ensure it’s reachable by Vercel and CORS allows the Vercel origin.
 
 Notes
-- vercel.json routes all paths to the Next.js app directory: ensure API proxy `/api/proxy` keeps working.
+- `vercel.json` builds from `trading-dashboard/` using `@vercel/next`.
 - For WS, prefer `NEXT_PUBLIC_WS_BASE` if you terminate TLS or path differs.
-

--- a/docs/PHASES.md
+++ b/docs/PHASES.md
@@ -1,0 +1,48 @@
+# Implementation Phases (Test After Each)
+
+This plan breaks work into three phases with explicit checkpoints and tests. We will update this document and `docs/PROGRESS.md` after each step to make resets/restarts painless.
+
+## Phase 1 — Foundation & Testability
+Goal: A stable backend with CRUD basics, docs, and test scaffolding passing locally.
+
+Scope:
+- Ensure `app/` is a proper Python package (`__init__.py`).
+- Settings + Journal CRUD are live (SQLite-friendly) and tested.
+- Assistant prompt references confidence spec.
+- Docs in place: Scope, Confidence, Roadmap, Phases.
+
+Checkpoints/Tests:
+- Run `pytest tests/test_settings_journal.py` and see both pass.
+- `GET /healthz` returns `{ok:true}`.
+
+## Phase 2 — Confidence Signals & Coach Integration
+Goal: Compute confidence from ATR, VWAP (RTH-anchored), EMA posture (1m + 5m), order-flow proxies (RVOL/OBV/CVD approx), and expose to the Coach.
+
+Scope:
+- Extend context builder (`app/services/compose.py`) with signals in `docs/CONFIDENCE.md`.
+- Update scoring engine to consume the new fields and output component breakdowns.
+- Add unit tests for indicators (EMA/ATR/aVWAP/OBV/CVD approx) — deterministic arrays (no network).
+- Coach tool returns include `confidence` and component rationale.
+
+Checkpoints/Tests:
+- `pytest -q tests/<new_indicator_tests>.py` all green.
+- Manual call to coach route shows confidence components in response.
+
+## Phase 3 — Live Streaming, Alerts & UI Wiring
+Goal: Real-time prices, actionable alerts, and “next best action” chips in UI.
+
+Scope:
+- Start WS + risk engine on lifespan; guard with env for tests.
+- Polygon WS client publishes `price` events to dashboard.
+- Alerts CRUD (ORM); alert poller evaluates conditions using Polygon aggregates and broadcasts WS `alert` with suggestions.
+- Dashboard surfaces confidence and ‘why’ per suggestion; alert actions prefill plan/sizing.
+
+Checkpoints/Tests:
+- Dashboard WS shows Connected; receives `risk` heartbeats and `price` updates (when POLYGON_API_KEY present).
+- Create an alert → trigger observed in UI and via `/api/v1/alerts/list`.
+- Unit test: Alerts CRUD endpoints pass (`tests/test_alerts_crud.py`).
+
+Notes:
+- No mock data: features silently disable without credentials; confidence uses quality multiplier.
+- Portability: ORM over raw SQL to support SQLite/Postgres.
+- Observability: structured logs; `/api/v1/diag/*` endpoints.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -108,3 +108,13 @@ Date: 2025-09-13
     2) Adds labels `automerge` and `codex` (best effort).
     3) Enables auto‑merge (squash). Merge will complete automatically once required checks pass and branch protection conditions are satisfied.
 - Note: Respects your branch protection. If approvals are required, auto‑merge waits for them.
+
+## Update — Initial Snapshot on UI Boot
+
+Date: 2025-09-13
+
+- Added client boot hook to fetch `/api/v1/stream/state` once and seed positions/orders/risk before WS updates arrive.
+- Files:
+  - `trading-dashboard/src/components/BootSnapshot.tsx`
+  - `trading-dashboard/app/layout.tsx` (renders BootSnapshot inside QueryProvider)
+- Benefit: Positions/Orders pages show server snapshot immediately; then WS keeps them fresh.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -95,3 +95,16 @@ Date: 2025-09-13
 - Added table view of active alerts with delete action.
 - Added Discord enablement hint.
 - File: `trading-dashboard/app/alerts/page.tsx`
+
+## Update — Auto PR + Auto‑Merge Workflow
+
+Date: 2025-09-13
+
+- Added workflow to automatically open a PR from feature branches to `main` on push, label it `automerge`, and enable GitHub’s auto‑merge (squash) using the repository `GITHUB_TOKEN`.
+- File: `.github/workflows/auto-pr-automerge.yml`
+- Behavior:
+  - On push to branches matching `feat/**`, `fix/**`, `chore/**`, `refactor/**` (and the current feature branch), the workflow:
+    1) Creates or finds an open PR to `main`.
+    2) Adds labels `automerge` and `codex` (best effort).
+    3) Enables auto‑merge (squash). Merge will complete automatically once required checks pass and branch protection conditions are satisfied.
+- Note: Respects your branch protection. If approvals are required, auto‑merge waits for them.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -54,3 +54,34 @@ Set on Railway:
 
 See `docs/UX_PLAN.md` for detailed UX/UI flow, feature review, and implementation plan focused on a responsible, production‑ready web app.
 
+---
+
+## Update — UI Components (Risk, Confidence, Inline Alerts)
+
+Date: 2025-09-13
+
+Implemented first-pass live UI pieces aligned to the plan:
+
+- Risk banner in status strip
+  - Shows `daily_r`, concurrent positions, and breach flags from WS `risk` events.
+  - File: `trading-dashboard/app/page.tsx`
+
+- Confidence card (Analyze)
+  - Score band chip with label (Unfavorable/Mixed/Favorable), component chips (ATR/VWAP/EMAs/Flow/Liquidity), and freshness seconds.
+  - Calls `/api/v1/compose-and-analyze` via the proxy.
+  - File: `trading-dashboard/app/page.tsx`
+
+- Inline Create Alert control
+  - Defaults to ±1R from entry; optional threshold % to offset from entry price.
+  - Posts to `/api/v1/alerts/set` with type `price_above|price_below` and `threshold_pct`.
+  - File: `trading-dashboard/app/page.tsx`
+
+Branch and PR
+- Branch: `feat/dashboard-live-confidence-discord`
+- Open PR: https://github.com/n8kahl/trading-dashboard-/pull/new/feat/dashboard-live-confidence-discord
+
+Pick-up Next
+- Confidence UI polish: colors, tooltips for components, “why” rationale text.
+- Alerts page enhancements: types/timeframe/expiry controls, live updates, Discord enablement hint.
+- Initial snapshot fetch for positions/orders; basic readonly lists.
+- Style Risk banner with severity colors and link to Settings.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -118,3 +118,11 @@ Date: 2025-09-13
   - `trading-dashboard/src/components/BootSnapshot.tsx`
   - `trading-dashboard/app/layout.tsx` (renders BootSnapshot inside QueryProvider)
 - Benefit: Positions/Orders pages show server snapshot immediately; then WS keeps them fresh.
+
+## Update — Vercel Monorepo Config
+
+Date: 2025-09-13
+
+- Added root `vercel.json` to direct Vercel to build and serve the Next.js app from `trading-dashboard/` in a monorepo.
+- File: `vercel.json`
+- Note: You still need to set Vercel env vars (see `trading-dashboard/.env.example`) and ensure the project’s Root Directory is the repository root (the config routes to the app subfolder).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,17 @@
+# Progress Log
+
+Lightweight log to record exactly where work left off. Update after each phase/test.
+
+## 2025-09-13
+- Added docs: SCOPE, ROADMAP, CONFIDENCE, PHASES, and linked from READMEs and assistant prompt.
+- Phase 1: Added `app/__init__.py` and `tests/conftest.py` to fix imports.
+- Phase 1: Settings/Journal CRUD tests PASS (`tests/test_settings_journal.py`).
+- Phase 2: Implemented ATR%/VWAP/EMA/order-flow signals in `app/services/compose.py` and indicator helpers in `app/services/ta.py`.
+- Phase 2: Extended scoring to include `atr_regime`, `dist_ema20`, and `flow` components.
+- Phase 2: Added tests `tests/test_confidence_signals.py` — all PASS.
+- Phase 3: Implemented Alerts CRUD and refactored poller to ORM + WS broadcast; added `tests/test_alerts_crud.py` (PASS).
+- Phase 3: Added optional background startup hooks (env: `ENABLE_BACKGROUND_LOOPS`, `ENABLE_ALERTS_POLLER`).
+ UI/UX: Added `docs/UIUX.md` with responsive design plan; updated SCOPE/ROADMAP for Discord alerts.
+ Settings: Added Discord webhook/filters to `AppSettings` and `/api/v1/settings/*` (DB fields + API serialization).
+ Poller: Posts alerts to Discord when enabled and type matches filters.
+ Next: Wire Polygon WS price events to broadcast; verify dashboard receives `price` events; add minimal E2E manual checklist.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -82,6 +82,16 @@ Branch and PR
 
 Pick-up Next
 - Confidence UI polish: colors, tooltips for components, “why” rationale text.
-- Alerts page enhancements: types/timeframe/expiry controls, live updates, Discord enablement hint.
+- Alerts page enhancements: types/timeframe/expiry controls, live updates, Discord enablement hint. [Done]
 - Initial snapshot fetch for positions/orders; basic readonly lists.
 - Style Risk banner with severity colors and link to Settings.
+
+## Update — Alerts Page Enhancements
+
+Date: 2025-09-13
+
+- Rewrote Alerts page to align with backend API (`/api/v1/alerts/list|set|delete/:id`).
+- Added create form fields: symbol, type (above/below), timeframe (minute/day), level, optional threshold %, optional expiry ISO.
+- Added table view of active alerts with delete action.
+- Added Discord enablement hint.
+- File: `trading-dashboard/app/alerts/page.tsx`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -126,3 +126,18 @@ Date: 2025-09-13
 - Added root `vercel.json` to direct Vercel to build and serve the Next.js app from `trading-dashboard/` in a monorepo.
 - File: `vercel.json`
 - Note: You still need to set Vercel env vars (see `trading-dashboard/.env.example`) and ensure the project’s Root Directory is the repository root (the config routes to the app subfolder).
+
+## Update — CI Deployments to Vercel (Preview & Production)
+
+Date: 2025-09-13
+
+- Added GitHub Actions workflow to build and deploy the Next.js app to Vercel using the Vercel CLI.
+- File: `.github/workflows/vercel-deploy.yml`
+- Behavior:
+  - On PRs: builds a Preview and comments the URL on the PR.
+  - On pushes to `main`: builds and deploys to Production.
+- Required repo secrets:
+  - `VERCEL_TOKEN` — personal or team token from Vercel
+  - `VERCEL_ORG_ID` — Organization ID (from Vercel → Settings → General → IDs)
+  - `VERCEL_PROJECT_ID` — Project ID (from Vercel Project → Settings → General → IDs)
+- Note: The project can also use the Vercel GitHub app; this workflow is a fallback/explicit pipeline with monorepo awareness (`trading-dashboard/`).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -141,3 +141,5 @@ Date: 2025-09-13
   - `VERCEL_ORG_ID` — Organization ID (from Vercel → Settings → General → IDs)
   - `VERCEL_PROJECT_ID` — Project ID (from Vercel Project → Settings → General → IDs)
 - Note: The project can also use the Vercel GitHub app; this workflow is a fallback/explicit pipeline with monorepo awareness (`trading-dashboard/`).
+
+Triggered CI to validate Vercel Preview deployment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation Index
+
+- Scope & Principles: `SCOPE.md`
+- Confidence Scoring (ATR, VWAP, EMAs, Order Flow, Liquidity): `CONFIDENCE.md`
+- Roadmap & Milestones: `ROADMAP.md`
+
+These documents define how the assistant computes confidence for trade ideas using real data (no mocks), the architecture for realtime streaming and alerts, and the delivery plan. The assistant’s behavior is aligned via `app/assistant/system_prompt.md`.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,0 +1,111 @@
+# Requirements — Providers, Natural Language Alerts, Next Best Actions, and Day-Trader UI
+
+This document codifies the functional and non‑functional requirements to deliver a live, responsible trading dashboard using chat-data.com (LLM), Polygon (market data, options), and Tradier (broker). It complements `docs/UX_PLAN.md` and `docs/ROADMAP.md`.
+
+## Providers & Capabilities
+
+- Polygon (Market Data)
+  - WebSocket: aggregate‑minute bars for equities (`AM.<SYMBOL>`), used for live prices, freshness, and intraday signals.
+  - HTTP: v2 aggregates (intraday/daily) for backfill; snapshots for resiliency.
+  - Options: v3 reference options contracts (universe); optional real‑time quotes if plan allows.
+  - Indicators (optional): EMA/RSI endpoints for convenience; otherwise computed client‑side.
+  - Env: `POLYGON_API_KEY` set on backend.
+  - Notes: If plan tier lacks intraday minute or options quotes, UI must degrade gracefully (daily fallbacks; label "not realtime").
+
+- Tradier (Broker)
+  - Endpoints: account, orders (place/cancel/replace), positions, options chains/expirations, quotes (underlying) for sizing sanity.
+  - Env: `TRADIER_ACCESS_TOKEN`, `TRADIER_ENV` (sandbox/live), `TRADIER_ACCOUNT_ID`.
+  - Safety: Never place orders without explicit user confirmation; sandbox toggles in Settings.
+
+- chat-data.com (LLM via OpenAI‑compatible API)
+  - Endpoint: OpenAI‑compatible Chat Completions with tool calling.
+  - Functions: natural language formatting of alerts; composing execution checklists; summarizing news; answering queries.
+  - Env: `CHATDATA_API_KEY` (required for LLM features), `CHATDATA_BASE_URL` (default `https://api.chat-data.com`), `CHATDATA_API_PATH` (default `/v1/chat/completions`), `CHATDATA_MODEL` (optional model ID).
+  - Privacy: Keep keys server‑side; frontend calls backend routes only.
+
+## Natural Language Alerts (NLA)
+
+- Triggers
+  - Backed by DB `Alert` rows with condition JSON (e.g., `price_above/below`, threshold %, timeframe, expiry).
+  - Poller checks active alerts on interval (`ALERT_POLL_SEC`); obtains price via Polygon (HTTP fallback acceptable).
+  - On trigger: create `AlertTrigger` row; broadcast WS `{ type:'alert', level, msg, meta }`.
+
+- Message Composition
+  - Fast path: deterministic template with symbol, condition met, current price, recency, and suggested next steps.
+  - Enriched path (if `CHATDATA_API_KEY` set and latency budget allows): LLM augments with brief rationale and confidence (0–100), citing ATR/VWAP/EMA/order‑flow/liquidity inputs (no hallucinated data).
+  - Latency budgets: p95 ≤ 3s for alert delivery; LLM enrichment should not block broadcast. If slow, send basic alert first and follow with enriched text.
+
+- Delivery
+  - WebSocket fan‑out to dashboard; optional Discord webhook forward when enabled in Settings (with allowed alert types).
+  - UI shows alert list with timestamp, reason, and Next Best Action (NBA) buttons.
+
+- Guardrails
+  - No automated execution from alerts; NBA buttons require user confirmation for sensitive actions (orders).
+  - Clear freshness labels; disclose data sources used.
+
+- Acceptance
+  - CRUD works; triggers persisted; alerts visible via WS; Discord forward respects filters.
+
+## Next Best Actions (NBA)
+
+- Buttons and Mappings
+  - Plan: calls `/api/v1/plan/validate` with current entry/stop → shows 1R/2R targets and sanity notes.
+  - Size It: calls `/api/v1/sizing/suggest` with risk budget → returns lot size; UI blocks oversize suggestions.
+  - Set Alert: prefilled thresholds (±1R) → `/api/v1/alerts/set`.
+  - Ask Coach: sends context to `/api/v1/coach/chat` to get checklist and confidence.
+  - Place Order: opens prefilled order modal; posts to `/api/v1/broker_tradier/*` only after explicit confirm; honors sandbox setting.
+
+- State/Enablement
+  - Buttons enable based on provider availability (e.g., Tradier key present to show Place Order).
+  - Tooltip and disabled states explain missing prerequisites.
+
+- Acceptance
+  - All NBA calls return within UX‑acceptable budgets: Plan/Sizing < 800ms; Alert Set < 500ms; Order flows depend on broker latency.
+
+## Day‑Trader‑First UI (Responsive)
+
+- Layout
+  - Dashboard: Watchlist → Picks → Analyze; live price/WS status; risk banner; alerts column; news panel.
+  - Mobile: collapsible sections; persistent status strip (WS/Risk/Price) and FAB for quick actions.
+  - Keyboard: quick symbol switch, focus inputs, submit actions (non‑destructive only) with shortcuts.
+
+- Confidence Surface
+  - Score band chip (0–100): unfavorable (<50), mixed (50–69), favorable (≥70).
+  - Component chips (ATR, VWAP, EMAs, Order‑Flow, Liquidity) with bounded contribution values.
+  - “Why” 1‑liner and data freshness timestamp.
+
+- Alerts UX
+  - Inline “Create Alert” with type, level, threshold %; defaults to ±1R.
+  - Alerts page: filters (active/expired), bulk disable, edit, delete.
+
+- Risk & Positions
+  - Risk banner: daily R, concurrent positions, breach indicators from WS.
+  - Positions/Orders: readonly lists first, then confirmable actions.
+
+- Responsible Design
+  - Confirmations on any broker action; sandbox switch visible.
+  - No secrets client‑side; proxy all API calls; WS token/query only if backend requires.
+  - Clear fallback messaging when minute data or options quotes are unavailable.
+
+## Performance & Observability
+
+- Performance budgets
+  - Initial snapshot (`/api/v1/stream/state`) < 400ms typical; WS connect < 500ms.
+  - Plan/Sizing < 800ms; Analyze (scoring) < 1200ms with warmed caches.
+
+- Observability
+  - Routes: `/api/v1/diag/health|ready|config|routes`.
+  - Structured logs for alerts, risk breaches, broker errors.
+  - Client surfacing of last event age and data source labels.
+
+## Security & Privacy
+
+- API key header (`X-API-Key`) on sensitive routes; CORS origins locked via env.
+- WS query param tokenization for dev; long‑term plan: signed tokens.
+- PII/Secrets: never rendered to client; Coach route handles LLM calls server‑side.
+
+## Dependencies & Env (recap)
+
+- Backend: `POLYGON_API_KEY`, `TRADIER_*`, `CHATDATA_*`, `ALERT_POLL_SEC`, `ENABLE_ALERTS_POLLER`, `ENABLE_BACKGROUND_LOOPS`, `ALLOWED_ORIGINS`.
+- Frontend: `NEXT_PUBLIC_API_BASE`, `NEXT_PUBLIC_WS_BASE` (optional), `NEXT_PUBLIC_API_KEY` (optional pass‑through).
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,33 +1,45 @@
 # Trading Assistant — Roadmap (V1)
 
+Note: This roadmap is actively maintained. At the start of each working session, review and update the checkboxes and notes below (Codex: do this first).
+
+Last reviewed: 2025-09-13
+
 ## M0 — Foundation (Backend + Dashboard)
-- [ ] FastAPI boots with lifespan, CORS configured, health/ready endpoints.
-- [ ] `AppSettings` + `Journal` CRUD live; tests green.
-- [ ] WebSocket connects; periodic `risk` broadcasts visible.
+- [x] FastAPI boots with lifespan, CORS configured, health/ready endpoints.
+- [x] `AppSettings` + `Journal` CRUD live; tests green.
+- [x] WebSocket connects; periodic `risk` broadcasts visible.
 
 ## M1 — Live Prices & Alerts
-- [ ] Polygon WS client publishes `price` for watchlist symbols.
-- [ ] Alerts CRUD with validation; list/create/update/delete.
-- [ ] Alert poller triggers via Polygon HTTP; creates `AlertTrigger` rows; WS `alert` fan‑out.
+- [x] Polygon WS client publishes `price` for watchlist symbols.
+- [ ] Alerts CRUD with validation; list/create/update/delete.  (update route pending)
+- [x] Alert poller triggers via Polygon HTTP; creates `AlertTrigger` rows; WS `alert` fan‑out.
 
 ## M2 — Planning & Sizing
-- [ ] `/plan/validate` returns NL summary + RR bands.
-- [ ] `/sizing/suggest` returns lot sizes from risk budget.
-- [ ] Frontend shows action buttons: Build Plan, Size It, Set Alert.
+- [x] `/plan/validate` returns NL summary + RR bands.
+- [x] `/sizing/suggest` returns lot sizes from risk budget.
+- [x] Frontend shows action buttons: Build Plan, Size It, Set Alert.
 
 ## M3 — Broker Workflow (Tradier)
-- [ ] Place/cancel orders; show statuses in Positions/Orders tabs.
-- [ ] Confirmations, errors, and journaling of executions.
+- [x] Place/cancel orders; show statuses in Positions/Orders tabs.
+- [ ] Confirmations, errors, and journaling of executions.  (journaling not yet wired)
 
 ## M4 — Coach Confidence & Guidance (chat-data)
-- [ ] Coach tools for quotes, picks, plan, sizing, set alert, place/cancel order, journal add.
-- [ ] Responses include `confidence` and cite data sources used.
+- [x] Coach tools for quotes, picks, plan, sizing, set alert, place/cancel order, journal add.
+- [ ] Responses include `confidence` and cite data sources used.  (compose-and-analyze available; wire into coach)
 
 ## Operational Readiness
-- [ ] Docs for required env vars: `POLYGON_API_KEY`, `TRADIER_ACCESS_TOKEN`, `TRADIER_ACCOUNT_ID`, `TRADIER_ENV`, `CHATDATA_*`, `DATABASE_URL`.
-- [ ] Observability: log structured events; `/api/v1/diag/*` documented.
-- [ ] Security posture: API key for sensitive routes; WS tokenization plan.
+- [x] Docs for required env vars: `POLYGON_API_KEY`, `TRADIER_ACCESS_TOKEN`, `TRADIER_ACCOUNT_ID`, `TRADIER_ENV`, `CHATDATA_*`, `DATABASE_URL`.
+- [x] Observability: log structured events; `/api/v1/diag/*` documented.
+- [~] Security posture: API key for sensitive routes; WS tokenization plan.  (WS tokenization TBD)
 ## M5 — Discord Alerts
 - [ ] Settings: webhook URL, enable toggle, allowed alert types (e.g., price_above, price_below, risk).
 - [ ] Poller forwards triggers to Discord when enabled and type matches.
 - [ ] Optional: risk breach alerts forwarded from risk engine.
+
+Status notes
+- Frontend dashboard + WS live; price/risk/alerts propagate over WS.
+- Alerts set/list/delete/update complete.
+- Sizing endpoint live; plan.validate to add NL summary + RR bands.
+- Tradier sandbox order preview/place wired; journaling to be attached to executions.
+- Coach integrated with ChatData; tools expanded for options + plan/sizing/broker/alerts/journal.
+- Discord alert forwarding implemented in poller; risk breach → Discord pending.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,33 @@
+# Trading Assistant — Roadmap (V1)
+
+## M0 — Foundation (Backend + Dashboard)
+- [ ] FastAPI boots with lifespan, CORS configured, health/ready endpoints.
+- [ ] `AppSettings` + `Journal` CRUD live; tests green.
+- [ ] WebSocket connects; periodic `risk` broadcasts visible.
+
+## M1 — Live Prices & Alerts
+- [ ] Polygon WS client publishes `price` for watchlist symbols.
+- [ ] Alerts CRUD with validation; list/create/update/delete.
+- [ ] Alert poller triggers via Polygon HTTP; creates `AlertTrigger` rows; WS `alert` fan‑out.
+
+## M2 — Planning & Sizing
+- [ ] `/plan/validate` returns NL summary + RR bands.
+- [ ] `/sizing/suggest` returns lot sizes from risk budget.
+- [ ] Frontend shows action buttons: Build Plan, Size It, Set Alert.
+
+## M3 — Broker Workflow (Tradier)
+- [ ] Place/cancel orders; show statuses in Positions/Orders tabs.
+- [ ] Confirmations, errors, and journaling of executions.
+
+## M4 — Coach Confidence & Guidance (chat-data)
+- [ ] Coach tools for quotes, picks, plan, sizing, set alert, place/cancel order, journal add.
+- [ ] Responses include `confidence` and cite data sources used.
+
+## Operational Readiness
+- [ ] Docs for required env vars: `POLYGON_API_KEY`, `TRADIER_ACCESS_TOKEN`, `TRADIER_ACCOUNT_ID`, `TRADIER_ENV`, `CHATDATA_*`, `DATABASE_URL`.
+- [ ] Observability: log structured events; `/api/v1/diag/*` documented.
+- [ ] Security posture: API key for sensitive routes; WS tokenization plan.
+## M5 — Discord Alerts
+- [ ] Settings: webhook URL, enable toggle, allowed alert types (e.g., price_above, price_below, risk).
+- [ ] Poller forwards triggers to Discord when enabled and type matches.
+- [ ] Optional: risk breach alerts forwarded from risk engine.

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -1,0 +1,145 @@
+# Trading Assistant — Scope & Principles
+
+## Vision
+A day trader’s command center that is intuitive, informative, and profitable. It combines live market data, actionable alerts, and an LLM coach to guide trade setups, execution, and management via natural language. No mock data; all insights are backed by live market and brokerage APIs.
+
+## Non‑Goals
+- No paper trading simulator beyond what the broker provides.
+- No historical backtester in v1.
+- No social features or multi‑tenant rooms in v1.
+
+## Core Principles
+- Live, real data only (Polygon, Tradier, earnings feeds, chat-data.com LLM).
+- Actionable UX: every surface offers a clear next best action.
+- Safety first: guardrails from risk engine and settings; explain “why”.
+- Observability: health, latency, data freshness are visible and alerting.
+- Modular: cleanly separated services and clear contracts.
+
+## User Outcomes
+- Discover high‑quality intraday setups with confidence scores.
+- Execute trades in a simple, few‑click workflow.
+- Receive timely, succinct alerts (w/ next best action suggestions).
+- Manage open positions with proactive guidance (trim/exit/roll/hedge).
+- Tune behavior from an intuitive Settings panel and persist in DB.
+
+---
+
+# Architecture Overview
+
+## Data Sources (no mock data)
+- Market data: Polygon
+  - HTTP: quotes/aggregates; WebSocket: live bars.
+- Broker: Tradier (orders, positions, balances, fills).
+- LLM: chat-data.com OpenAI‑compatible endpoint for reasoning & NLA tools.
+- Earnings/news: via Polygon and curated feeds; LLM can summarize/augment.
+ - Alerts to Discord: optional per Settings (webhook + filter by type).
+
+## Backend (FastAPI)
+- Routers
+  - `/api/v1/stream/*`: stream snapshots for positions/orders/risk; WS at `/ws`.
+  - `/api/v1/options/*`: screening/picks and pricing (inputs backed by Polygon/Tradier only).
+  - `/api/v1/alerts/*`: CRUD alerts; triggers fan‑out to WS + persistence.
+  - `/api/v1/plan`, `/api/v1/sizing`: validate setups and compute risk‑aligned sizing.
+  - `/api/v1/broker/*`: account, orders (place/cancel), positions (Tradier).
+  - `/api/v1/coach/*`: LLM chat, tools for data fetch, plan/sizing, and journaling.
+  - `/api/v1/journal/*`: trade journal CRUD.
+  - `/api/v1/settings/*`: admin settings CRUD.
+  - `/api/v1/diag/*`: health/ready/config.
+- Services
+  - `core/ws`: connection manager; broadcast JSON events to dashboard.
+  - `core/risk`: periodic risk evaluation; emits risk state + breach alerts.
+  - `services/stream`: Polygon WS client; maintains recent bars and broadcasts price ticks.
+  - `services/poller`: alert poller using Polygon HTTP aggregates; triggers when conditions met.
+  - `services/providers/tradier`: broker client for orders/positions.
+  - `integrations/chatdata`: minimal OpenAI‑compatible chat client.
+- Persistence (SQLAlchemy)
+  - `AppSettings`, `Alert`, `AlertTrigger`, `JournalEntry`, plus paper tables as needed.
+- Security
+  - API key header for sensitive routes; WS query param for dev; rotate to token later.
+
+## Frontend (Next.js)
+- Real‑time WS client: reflects positions / orders / risk / alert / price.
+- Pages
+  - Dashboard: watchlist, top picks, live prices, alerts, quick actions.
+  - Coach: chat-data LLM with tools (plan/sizing/fetch/execute/journal/add alert).
+  - Orders/Positions: live management and one‑click next actions (trim/close/roll).
+  - Alerts: list/create/edit with conditions and expirations; actionable chips.
+  - Journal: log entries, attach plans/LLM rationale, export.
+  - Admin/Settings: risk limits, defaults, universe, API keys (server‑only secrets).
+- Components: AlertsPanel, NewsPanel, Pick cards, Position tiles, Risk banner.
+
+## Events over WebSocket
+- `risk`: `{ type: "risk", state }`
+- `alert`: `{ type: "alert", level, msg, meta? }`
+- `positions`: `{ type: "positions", items }`
+- `orders`: `{ type: "orders", items }`
+- `price`: `{ type: "price", symbol, last }`
+
+---
+
+# Feature Scope (V1)
+
+## 1) Live Data & WS
+- Start WS and risk engine at app startup.
+- Polygon WS client publishes `price` events for watchlist symbols.
+- Stream snapshot endpoints used for initial page load; WS for updates.
+
+## 2) Alerts (Actionable)
+- CRUD backed by DB. Conditions: price_above/below with optional threshold_pct; timeframe minute/day; optional expiry.
+- Poller checks conditions every `ALERT_POLL_SEC`. On trigger:
+  - Persist `AlertTrigger` row; mark first trigger timestamp.
+  - Broadcast WS `alert` with suggested next best actions, e.g.,
+    - “Take TSLA scalp setup (1R risk)?”
+    - “Trim SPY — level approaching.”
+- LLM tool can enrich alert message with rationale when latency allows.
+
+## 3) Trade Planning & Sizing
+- `/plan/validate`: validate entry/stop; compute RR bands; return NL summary.
+- `/sizing/suggest`: share of risk budget; lot size; confidence score tie‑in.
+- Coach tool uses both to propose an execution checklist.
+
+## 4) Broker Execution
+- Place/cancel/replace orders via Tradier; return IDs and broker echoes.
+- “Next best action” buttons produce prefilled orders; user confirms.
+
+## 5) Coach (chat-data)
+- Tools exposed: quotes, picks, plan/sizing, set alert, place/cancel order, journal add.
+- Returns: content + `confidence` (0–1) per suggestion; cites data sources used.
+- Guardrails: never execute trades without explicit user confirm.
+
+## 6) Settings & Risk
+- Settings persisted in `app_settings`. Risk engine reads limits and emits warnings.
+- UI toggles for sandbox/production, default RR, top symbols, etc.
+
+---
+
+# Milestones & Acceptance Criteria
+
+## M0 — Foundation
+- Health endpoints pass; `settings/journal` CRUD pass tests.
+- WS connects; `risk` heartbeats visible in UI.
+
+## M1 — Live Prices & Alerts
+- Polygon WS running; dashboard receives `price` for watchlist symbols.
+- Alerts CRUD + poller working; triggers broadcast WS `alert` with action chips.
+
+## M2 — Planning & Sizing
+- Endpoints return consistent structures with NL summaries; unit tests for edge cases.
+- Coach toolchain composes a step‑by‑step execution checklist.
+
+## M3 — Broker Workflow
+- Place/cancel orders; confirmation and error states handled; audit in journal.
+
+## M4 — Coach Confidence & Guidance
+- All suggestions include `confidence`, rationale, and links to underlying data.
+
+KPIs: WS uptime > 99%, quote latency p95 < 1.5s, alert delivery p95 < 3s, plan compute < 800ms, API error rate < 1%.
+
+---
+
+# Implementation Notes
+- No mock data: features are disabled when credentials missing; UI communicates why.
+- DB portability: use SQLAlchemy ORM for SQLite/Postgres compatibility.
+- Background tasks: start in FastAPI lifespan; cancel cleanly on shutdown.
+- Observability: log structured events; expose `/api/v1/diag/health|ready|config`.
+- Security: keep secrets server‑side; signed action tokens for WS in future.

--- a/docs/UIUX.md
+++ b/docs/UIUX.md
@@ -1,0 +1,65 @@
+# UI/UX Blueprint and Responsive Design
+
+This document captures the approved flows and responsive design plan.
+
+## Navigation
+- Dashboard: live watchlist, top picks, prices, alerts.
+- Coach: chat-data LLM with tool-powered actions.
+- Positions/Orders: live grids with inline actions.
+- Alerts: list/create/edit; triggers with next-best actions.
+- Journal: entries linked to trades and rationales.
+- Settings: risk, universe, execution, LLM, API keys, Discord alerts.
+
+## Global Frame
+- WS status dot + latency; market clock; data freshness.
+- Risk banner (limits + breach states) with guidance.
+- Toasts for alerts; Next Best Action chips where relevant.
+- Keyboard shortcuts: B=Build Plan, Z=Size, A=Alert, O=Order preview, Enter=Confirm, Esc=Cancel.
+
+## Dashboard
+- Watchlist: editable, shows last, Δ, RVOL hint.
+- Top Picks: cards with confidence ring and chips (ATR, VWAP, EMA, Flow, Liquidity) + tooltips.
+- Inline Plan/Size/Alert: entry/stop inputs; quick actions.
+- Right Rail: Alerts panel (live, actionable), News panel, Coach shortcuts.
+
+## Coach
+- Threaded chat; responses include: summary, confidence (0–100) with breakdown, why-now, action buttons (Plan, Size, Set Alert, Place).
+- Cites data used (VWAP RTH, EMAs, ATR%, RVOL/Flow).
+
+## Positions/Orders
+- Live grids, inline actions: Trim %, Move stop, Close, Roll.
+- Bracket builder drawer: preview + confirm; respects guardrails.
+
+## Alerts
+- Table: symbol, condition, timeframe, active/expiry, last trigger; filter/search.
+- Create modal: price above/below with threshold %, timeframe, expiry.
+- Trigger UX: toast + panel item with Take/Trim chips opening prefilled flows.
+- Discord alerts: configurable via Settings (webhook, enabled, types).
+
+## Journal
+- Timeline linked to orders/alerts; tags; AI summaries optional.
+
+## Settings
+- Risk: daily R cap, max concurrent, default RR, sandbox/live toggle.
+- Universe: top symbols; sector presets.
+- Execution: defaults (TIF, bracket template).
+- LLM: model, permissions, include confidence breakdown.
+- Integrations: Polygon, Tradier, chat-data (test buttons).
+- Alerts → Discord: webhook URL, enabled toggle, alert types to forward (e.g., "price_above,price_below,risk").
+- Advanced: component weights for confidence (server-provided), reset to defaults.
+
+## Responsive Design
+- Layout grid uses fluid CSS Grid/Flex with breakpoints:
+  - ≥1280px: 2-column main area with right rail; cards grid auto-fit minmax(320px,1fr).
+  - 768–1279px: single column main; right rail stacks below; cards auto-fit minmax(280px,1fr).
+  - <768px: single column; condensed cards, collapsible sections; hide non-critical metrics behind tooltips.
+- Typography scales via clamp(); buttons and inputs maintain min touch targets (44px).
+- High-contrast theme support; color not the only encoder (icons/labels for confidence/risk).
+- WS/latency + freshness indicators collapse to compact badges on small screens.
+
+## Acceptance Criteria
+- Dashboard adapts to <768px with stacked sections and readable cards.
+- Confidence ring and chips remain legible and accessible across breakpoints.
+- Alerts and Next Best Action chips remain one-tap/one-click reachable on mobile widths.
+- Settings exposes Discord webhook, enabled, and type filters; test message button optional.
+

--- a/docs/UX_PLAN.md
+++ b/docs/UX_PLAN.md
@@ -29,8 +29,8 @@ This plan focuses on a live, production‑ready trading dashboard with clear nex
 2) Discovery → Analysis → Action
 - Pick symbol from Watchlist → backend `/options/pick` returns top 5 contracts.
 - Live price renders from WS; stale badge if `age_sec > 60`.
-- Analyze: Call `/compose-and-analyze` → show score band (0–100) and components (ATR, VWAP, EMA, Flow, Liquidity) with concise rationale.
-- Quick actions: “Size It”, “Set Alert”, “Ask Coach” (pre‑filled prompt).
+- Analyze: Call `/compose-and-analyze` → show score band (0–100) and components (ATR, VWAP, EMA, Flow, Liquidity) with concise rationale and data freshness.
+- Quick actions (NBA): “Plan”, “Size It”, “Set Alert”, “Ask Coach”. Place Order only shows when broker keys present and user confirms.
 
 3) Plan & Sizing
 - Plan: `/plan/validate` validates entry/stop → shows 1R/2R targets and sanity notes.
@@ -38,9 +38,9 @@ This plan focuses on a live, production‑ready trading dashboard with clear nex
 - Confirmations: Always require explicit confirmation before any broker action.
 
 4) Alerts
-- Create: Inline control on Dashboard; CRUD in Alerts page.
+- Create: Inline control on Dashboard; CRUD in Alerts page. Defaults to ±1R levels with type (above/below), timeframe (minute/day), and optional expiry.
 - Poller: Backend checks and emits WS `alert`; optional Discord forward if enabled.
-- UI: Action chips (“Size now”, “Open Coach”) link to next steps.
+- UI: Action chips (NBA) — “Plan”, “Size It”, “Ask Coach”, “Set Follow‑Up Alert”.
 
 5) Orders & Positions (when broker keys present)
 - Positions and Orders stream via snapshot + WS; risk banner warns on breaches.
@@ -67,11 +67,11 @@ This plan focuses on a live, production‑ready trading dashboard with clear nex
 
 2. Confidence UI Component
 - Band chip (unfavorable <50, mixed 50–69, favorable ≥70), timestamp, rationale.
-- Component breakdown chips: ATR, VWAP, EMAs, Flow, Liquidity (with contributions).
+- Component breakdown chips: ATR, VWAP, EMAs, Flow, Liquidity (with contributions and tooltips explaining signals).
 
 3. Alerts UX
-- Inline “Create Alert” (price_above/below) with smart defaults (±1R).
-- Alerts page: filters, toggles, expires_at; real‑time updates.
+- Inline “Create Alert” (price_above/below) with smart defaults (±1R) and threshold %.
+- Alerts page: filters, toggles, expires_at; real‑time updates and Discord enablement hint.
 
 4. Risk Banner
 - Show current `risk.state`; badge colors on breaches; link to Settings.
@@ -89,7 +89,7 @@ This plan focuses on a live, production‑ready trading dashboard with clear nex
 ## Implementation Plan (Backend Touchpoints)
 - Stream: ensure `/ws` emits `price`, `risk`, `alert`; `/stream/state` used for initial page load.
 - CORS: keep env‑driven; lock down in production.
-- Compose/Analyze: ensure score components include ATR/VWAP/EMA/Flow/Liquidity.
+- Compose/Analyze: ensure score components include ATR/VWAP/EMA/Flow/Liquidity; expose freshness and bars_count for quality multiplier.
 - Alerts: ensure poller covers minute + day TF; persist triggers; optional Discord forward.
 
 ## Milestones
@@ -98,4 +98,3 @@ This plan focuses on a live, production‑ready trading dashboard with clear nex
 - M2: Positions/Orders (readonly) + Size/Plan integration
 - M3: Broker actions with confirm flows + Journal logging
 - M4: Discord alert forwarding acceptance + Observability pass
-

--- a/docs/UX_PLAN.md
+++ b/docs/UX_PLAN.md
@@ -1,0 +1,101 @@
+# UX/UI Flow & Implementation Plan — Responsible Web App
+
+This plan focuses on a live, production‑ready trading dashboard with clear next actions, safety guardrails, and real‑time data — avoiding mock data by design.
+
+## Principles
+- Real data only: Live Polygon and Tradier integrations; LLM calls via server.
+- Responsible UX: Clear confirmations, risk guardrails, data provenance and freshness.
+- Observer first: Always show what’s happening (WS state, risk, data timestamps).
+- Progressive disclosure: Simple defaults; advanced controls behind expanders.
+- Performance: Stream initial snapshots, then update over WS.
+
+## Top‑Level Navigation
+- Dashboard: Watchlist, picks, price tape, analysis (confidence), alerts, news.
+- Coach: Chat to plan/summarize; tools for quotes, plan/sizing, set alert, journal.
+- Plan & Sizing: Validate entry/stop and compute position size from risk budget.
+- Alerts: List/create/edit with status and quick actions.
+- Positions & Orders: Live broker state with “next best action” buttons.
+- Journal: CRUD entries with links to plans and LLM rationale.
+- Admin/Settings: Risk limits, universe, keys (server‑only secrets), Discord alerts.
+- Diagnostics: Health, config, routes; useful in staging.
+
+## End‑to‑End UX Flows
+
+1) First‑Run Setup
+- User loads Dashboard → sees WS status, “Not configured” hints if keys missing.
+- Admin sets API keys and risk defaults → backend persists to DB.
+- Optional: Enable background loops (WS pings, risk, poller) via env.
+
+2) Discovery → Analysis → Action
+- Pick symbol from Watchlist → backend `/options/pick` returns top 5 contracts.
+- Live price renders from WS; stale badge if `age_sec > 60`.
+- Analyze: Call `/compose-and-analyze` → show score band (0–100) and components (ATR, VWAP, EMA, Flow, Liquidity) with concise rationale.
+- Quick actions: “Size It”, “Set Alert”, “Ask Coach” (pre‑filled prompt).
+
+3) Plan & Sizing
+- Plan: `/plan/validate` validates entry/stop → shows 1R/2R targets and sanity notes.
+- Sizing: `/sizing/suggest` uses risk budget and per‑unit risk → outputs lots/qty.
+- Confirmations: Always require explicit confirmation before any broker action.
+
+4) Alerts
+- Create: Inline control on Dashboard; CRUD in Alerts page.
+- Poller: Backend checks and emits WS `alert`; optional Discord forward if enabled.
+- UI: Action chips (“Size now”, “Open Coach”) link to next steps.
+
+5) Orders & Positions (when broker keys present)
+- Positions and Orders stream via snapshot + WS; risk banner warns on breaches.
+- Action buttons populate sidecars/modals with prefilled orders; user confirms.
+
+## Responsible Design
+- Guardrails: Risk engine emits breach alerts; UI blocks oversized sizing suggestions.
+- Confirmations: No auto‑trade; explicit confirm on any broker action.
+- Privacy: Secrets server‑side; client uses proxy; no keys in browser storage.
+- Transparency: Data freshness timestamps and “why” breakdown on confidence.
+- Fail‑open strategy: Where appropriate, return helpful fallbacks without crashing.
+
+## Feature Review & Acceptance
+- Live Data: Price ticks, risk heartbeats visible; fallback clearly labeled.
+- Alerts: CRUD + poller; triggers fan‑out via WS and optional Discord.
+- Analysis: Score band + components; rationale text citing data used.
+- Plan/Sizing: Consistent structures; handles edge cases gracefully.
+- Broker: Place/cancel/replace; audit errors and confirmations in journal.
+
+## Implementation Plan (Frontend)
+1. Connectivity & Shell
+- Done: API proxy, WS env, API key pass‑through.
+- Add: initial snapshot fetch `/api/v1/stream/state` on load.
+
+2. Confidence UI Component
+- Band chip (unfavorable <50, mixed 50–69, favorable ≥70), timestamp, rationale.
+- Component breakdown chips: ATR, VWAP, EMAs, Flow, Liquidity (with contributions).
+
+3. Alerts UX
+- Inline “Create Alert” (price_above/below) with smart defaults (±1R).
+- Alerts page: filters, toggles, expires_at; real‑time updates.
+
+4. Risk Banner
+- Show current `risk.state`; badge colors on breaches; link to Settings.
+
+5. Positions/Orders Pages
+- Readonly list first using snapshot + WS; wire actions gradually.
+- Sidecar modals for confirm flows; guard with API key and sandbox flags.
+
+6. Coach Page
+- Maintain tool‑aware prompts; add “Insert Plan/Sizing/Alert” quick chips.
+
+7. Settings Page (Admin)
+- Fully wire Discord webhook & alert filters; test end‑to‑end with poller.
+
+## Implementation Plan (Backend Touchpoints)
+- Stream: ensure `/ws` emits `price`, `risk`, `alert`; `/stream/state` used for initial page load.
+- CORS: keep env‑driven; lock down in production.
+- Compose/Analyze: ensure score components include ATR/VWAP/EMA/Flow/Liquidity.
+- Alerts: ensure poller covers minute + day TF; persist triggers; optional Discord forward.
+
+## Milestones
+- M0: Connectivity + Analyze UI + Alerts create (live)
+- M1: Confidence component breakdown + Risk banner
+- M2: Positions/Orders (readonly) + Size/Plan integration
+- M3: Broker actions with confirm flows + Journal logging
+- M4: Discord alert forwarding acceptance + Observability pass
+

--- a/scripts/setup_env.py
+++ b/scripts/setup_env.py
@@ -43,6 +43,10 @@ def main():
     tradier_env = prompt("TRADIER_ENV [sandbox|production] (optional)", optional=True, default="sandbox")
     db_url = prompt("DATABASE_URL (leave blank for SQLite)", optional=True)
     tz = prompt("APP_TIMEZONE", default="America/Chicago")
+    chat_key = prompt("CHATDATA_API_KEY (optional)", optional=True, secret=True)
+    chat_base = prompt("CHATDATA_BASE_URL (optional)", optional=True, default="https://api.chat-data.com")
+    chat_path = prompt("CHATDATA_API_PATH (optional)", optional=True, default="/v1/chat/completions")
+    chat_model = prompt("CHATDATA_MODEL (optional)", optional=True)
 
     ENV_PATH.write_text(
         "\\n".join(
@@ -53,6 +57,10 @@ def main():
                 f"TRADIER_ENV={tradier_env}",
                 f"DATABASE_URL={db_url}",
                 f"APP_TIMEZONE={tz}",
+                f"CHATDATA_API_KEY={chat_key}",
+                f"CHATDATA_BASE_URL={chat_base}",
+                f"CHATDATA_API_PATH={chat_path}",
+                f"CHATDATA_MODEL={chat_model}",
             ]
         )
         + "\\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# Ensure repository root is on sys.path so `import app` works under pytest
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+

--- a/tests/test_alerts_crud.py
+++ b/tests/test_alerts_crud.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+
+from fastapi.testclient import TestClient
+
+
+def make_client():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    os.environ["DATABASE_URL"] = f"sqlite:///{path}"
+    from app.db import init_db
+    from app.main import app
+
+    init_db()
+    return TestClient(app)
+
+
+def test_alerts_crud_flow():
+    c = make_client()
+    # create
+    body = {"symbol": "SPY", "timeframe": "day", "condition": {"type": "price_above", "value": 100.0}}
+    r = c.post("/api/v1/alerts/set", json=body)
+    assert r.status_code == 200
+    aid = r.json()["id"]
+    # list
+    r2 = c.get("/api/v1/alerts/list")
+    assert r2.status_code == 200
+    items = r2.json().get("items") or []
+    assert any(it.get("id") == aid for it in items)
+    # delete
+    r3 = c.post(f"/api/v1/alerts/delete/{aid}")
+    assert r3.status_code == 200
+    r4 = c.get("/api/v1/alerts/list")
+    ids = [it.get("id") for it in r4.json().get("items") or []]
+    assert aid not in ids
+

--- a/tests/test_confidence_signals.py
+++ b/tests/test_confidence_signals.py
@@ -1,0 +1,101 @@
+from app.services.ta import ema, atr_1m, atr_1m_pct, anchored_vwap, obv_slope_10, cvd_approx_20
+from app.services.scoring_engine import score_vwap_bounce
+
+
+def make_bars(vals):
+  # vals: list of tuples (o,h,l,c,v)
+  out = []
+  t = 0
+  for o,h,l,c,v in vals:
+    out.append({"t": t, "o": o, "h": h, "l": l, "c": c, "v": v})
+    t += 60_000
+  return out
+
+
+def test_ema_basic():
+  xs = [1,2,3,4,5,6,7,8,9]
+  e3 = ema(xs, 3)
+  assert isinstance(e3, float)
+  assert 7.0 < e3 < 9.0  # rough bound
+
+
+def test_atr_and_pct():
+  bars = make_bars([
+    (10, 11, 9, 10, 1000),
+    (10, 12, 10, 11, 1000),
+    (11, 12, 11, 12, 1000),
+    (12, 13, 11, 12.5, 1000),
+    (12.5, 13, 12, 12.8, 1000),
+    (12.8, 13.5, 12.5, 13.2, 1000),
+    (13.2, 13.7, 12.9, 13.4, 1000),
+    (13.4, 13.9, 13.0, 13.7, 1000),
+    (13.7, 14.0, 13.4, 13.9, 1000),
+    (13.9, 14.1, 13.8, 14.0, 1000),
+    (14.0, 14.2, 13.9, 14.1, 1000),
+    (14.1, 14.3, 13.8, 14.0, 1000),
+    (14.0, 14.1, 13.7, 13.9, 1000),
+    (13.9, 14.0, 13.6, 13.8, 1000),
+    (13.8, 14.0, 13.7, 13.9, 1000),
+  ])
+  a = atr_1m(bars, period=14)
+  assert a is not None and a > 0
+  ap = atr_1m_pct(bars, period=14)
+  assert ap is not None and 0 < ap < 10
+
+
+def test_anchored_vwap_basic():
+  # price rises with constant volume; anchored later should be higher
+  bars = make_bars([
+    (10, 10.5, 9.5, 10.2, 1000),
+    (10.2, 10.7, 10.0, 10.5, 1000),
+    (10.5, 11.0, 10.4, 10.9, 1000),
+    (10.9, 11.3, 10.8, 11.1, 1000),
+  ])
+  v0 = anchored_vwap(bars, 0)
+  v2 = anchored_vwap(bars, 2)
+  assert v0 is not None and v2 is not None
+  assert v2 > v0
+
+
+def test_oflow_and_scoring_positive():
+  # Up bars → positive OBV slope and CVD
+  bars = make_bars([
+    (10, 10.5, 9.8, 10.4, 1000),
+    (10.4, 10.8, 10.2, 10.6, 1200),
+    (10.6, 11.0, 10.5, 10.9, 1500),
+    (10.9, 11.2, 10.8, 11.0, 1500),
+    (11.0, 11.3, 10.9, 11.1, 1600),
+    (11.1, 11.4, 10.9, 11.3, 1700),
+    (11.3, 11.5, 11.0, 11.4, 1700),
+    (11.4, 11.6, 11.2, 11.5, 1800),
+    (11.5, 11.7, 11.3, 11.6, 1800),
+    (11.6, 11.8, 11.4, 11.7, 1800),
+    (11.7, 11.9, 11.5, 11.8, 1800),
+  ])
+  obv = obv_slope_10(bars)
+  cvd = cvd_approx_20(bars)
+  assert obv is not None and obv > 0
+  assert cvd is not None and cvd > 0
+
+  # Scoring context with positive confluence
+  price = bars[-1]["c"]
+  vwap = (bars[-1]["c"] + bars[-1]["o"]) / 2  # rough, ensure price >= vwap
+  ctx = {
+    "price": price,
+    "vwap": vwap,
+    "bars_above_vwap": 2,
+    "ema9_gt_ema20": True,
+    "atr_1m_pct": 2.5,
+    "dist_ema20_pct": 0.2,
+    "obv_slope_10": obv,
+    "cvd_approx_20": cvd,
+    "divergence_5m": "bullish_confirmed",
+  }
+  out = score_vwap_bounce(ctx)
+  assert isinstance(out.get("score"), (int, float))
+  comp = out.get("components", {})
+  # New components should be present and non-negative in this bullish case
+  assert "atr_regime" in comp
+  assert "dist_ema20" in comp
+  assert "flow" in comp and comp["flow"] >= 0
+  assert out["score"] >= 40

--- a/tests/test_settings_journal.py
+++ b/tests/test_settings_journal.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import importlib
+import tempfile
+
+from fastapi.testclient import TestClient
+
+
+def make_client():
+    # point to a temporary sqlite db file
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    os.environ["DATABASE_URL"] = f"sqlite:///{path}"
+    # Import after env set; ensure we load the real module (not a prior test stub)
+    if 'app.db' in sys.modules:
+        del sys.modules['app.db']
+    from app.db import init_db
+    from app.main import app
+
+    init_db()
+    return TestClient(app)
+
+
+def test_settings_crud():
+    c = make_client()
+    r = c.get("/api/v1/settings/get")
+    assert r.status_code == 200
+    assert r.json()["ok"]
+    payload = {
+        "risk_daily_r": 3.0,
+        "risk_per_trade_r": 0.5,
+        "risk_max_concurrent": 4,
+        "rr_default": "1:5",
+        "auto_execute_sandbox": False,
+        "top_symbols": "SPY,QQQ,AAPL,NVDA,MSFT,TSLA,META",
+    }
+    r2 = c.post("/api/v1/settings/set", json=payload)
+    assert r2.status_code == 200
+    r3 = c.get("/api/v1/settings/get")
+    s = r3.json()["settings"]
+    for k, v in payload.items():
+        assert s[k] == v
+
+
+def test_journal_crud():
+    c = make_client()
+    # create
+    r = c.post("/api/v1/journal/create", json={"symbol": "SPY", "notes": "Test entry"})
+    assert r.status_code == 200
+    jid = r.json()["id"]
+    # list
+    r2 = c.get("/api/v1/journal/list?symbol=SPY")
+    assert r2.status_code == 200
+    items = r2.json()["items"]
+    assert any(it["id"] == jid for it in items)
+    # update
+    r3 = c.post(f"/api/v1/journal/update/{jid}", json={"r": 0.4, "side": "long"})
+    assert r3.status_code == 200
+    # delete
+    r4 = c.post(f"/api/v1/journal/delete/{jid}")
+    assert r4.status_code == 200
+    r5 = c.get("/api/v1/journal/list?symbol=SPY")
+    ids = [it["id"] for it in r5.json()["items"]]
+    assert jid not in ids

--- a/trading-dashboard/README.md
+++ b/trading-dashboard/README.md
@@ -6,3 +6,15 @@
 - Toast appears when an `alert` message is received over WebSocket.
 
 Run with `pnpm dev` from this directory.
+
+### Environment
+
+- `NEXT_PUBLIC_API_BASE` should point to your FastAPI backend base (e.g., `http://localhost:8000`).
+
+### Design & Confidence
+
+- App scope and architecture: see `../docs/SCOPE.md`
+- Confidence scoring (ATR, VWAP, EMAs, order flow): see `../docs/CONFIDENCE.md`
+- Roadmap/milestones: see `../docs/ROADMAP.md`
+
+The UI surfaces confidence and a short “why” for each suggestion. Components reflect ATR% regime, VWAP posture, EMA posture, RVOL/flow, and liquidity — computed from live data.

--- a/trading-dashboard/app/admin/settings/page.tsx
+++ b/trading-dashboard/app/admin/settings/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { apiGet, apiPost } from "@/src/lib/api";
+import { useState, useEffect } from "react";
+
+type Settings = {
+  risk_daily_r?: number|null;
+  risk_per_trade_r?: number|null;
+  risk_max_concurrent?: number|null;
+  rr_default?: string|null;
+  auto_execute_sandbox?: boolean;
+  top_symbols?: string|null;
+  discord_webhook_url?: string|null;
+  discord_alerts_enabled?: boolean;
+  discord_alert_types?: string|null;
+};
+
+export default function SettingsPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["settings"],
+    queryFn: async (): Promise<Settings> => (await apiGet("/api/v1/settings/get")).settings,
+  });
+  const [local, setLocal] = useState<Settings | null>(null);
+
+  useEffect(() => { if (data) setLocal(data); }, [data]);
+
+  const save = useMutation({
+    mutationFn: async () => apiPost("/api/v1/settings/set", local),
+  });
+
+  return (
+    <main className="container">
+      <h1 style={{marginBottom:12}}>Admin Settings</h1>
+      {isLoading ? "Loading…" : error ? String(error) : (
+        <section className="card" style={{display:"grid", gridTemplateColumns:"repeat(auto-fit,minmax(280px,1fr))", gap:12}}>
+          <label>Daily loss cap (R)
+            <input className="input" value={local?.risk_daily_r ?? ''} onChange={e=>setLocal(v=>({...v!, risk_daily_r: e.target.value?Number(e.target.value):null}))} />
+          </label>
+          <label>Per-trade max R
+            <input className="input" value={local?.risk_per_trade_r ?? ''} onChange={e=>setLocal(v=>({...v!, risk_per_trade_r: e.target.value?Number(e.target.value):null}))} />
+          </label>
+          <label>Max concurrent positions
+            <input className="input" value={local?.risk_max_concurrent ?? ''} onChange={e=>setLocal(v=>({...v!, risk_max_concurrent: e.target.value?Number(e.target.value):null}))} />
+          </label>
+          <label>Default R:R
+            <input className="input" placeholder="1:5" value={local?.rr_default ?? ''} onChange={e=>setLocal(v=>({...v!, rr_default: e.target.value}))} />
+          </label>
+          <label style={{gridColumn:"1 / -1"}}>Top symbols (comma-separated)
+            <input className="input" value={local?.top_symbols ?? ''} onChange={e=>setLocal(v=>({...v!, top_symbols: e.target.value}))} />
+          </label>
+          <label>
+            <input type="checkbox" checked={!!local?.auto_execute_sandbox} onChange={e=>setLocal(v=>({...v!, auto_execute_sandbox: e.target.checked}))} />
+            {' '}Allow auto-execute in Sandbox
+          </label>
+          <div style={{gridColumn:"1 / -1", marginTop:8, opacity:.8, fontWeight:600}}>Discord Alerts</div>
+          <label style={{gridColumn:"1 / -1"}}>Webhook URL
+            <input className="input" placeholder="https://discord.com/api/webhooks/..." value={local?.discord_webhook_url ?? ''} onChange={e=>setLocal(v=>({...v!, discord_webhook_url: e.target.value}))} />
+          </label>
+          <label>
+            <input type="checkbox" checked={!!local?.discord_alerts_enabled} onChange={e=>setLocal(v=>({...v!, discord_alerts_enabled: e.target.checked}))} />
+            {' '}Enable Discord forwarding
+          </label>
+          <label style={{gridColumn:"1 / -1"}}>Alert types (comma-separated)
+            <input className="input" placeholder="price_above,price_below,risk" value={local?.discord_alert_types ?? ''} onChange={e=>setLocal(v=>({...v!, discord_alert_types: e.target.value}))} />
+          </label>
+          <div style={{gridColumn:"1 / span 2"}}>
+            <button onClick={()=> save.mutate()} disabled={!local || save.isPending}>{save.isPending?"Saving…":"Save Settings"}</button>
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/trading-dashboard/app/alerts/page.tsx
+++ b/trading-dashboard/app/alerts/page.tsx
@@ -4,61 +4,155 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiGet, apiPost } from "@/src/lib/api";
 
-type AlertsList = { status: string; data: { alerts: Array<Record<string, any>> } };
+type AlertItem = {
+  id: number;
+  symbol: string;
+  timeframe?: "minute" | "day";
+  condition: { type: "price_above" | "price_below"; value: number; threshold_pct?: number };
+  expires_at?: string | null;
+  is_active?: boolean;
+  created_at?: string | null;
+};
+
+type AlertsListResp = { ok: boolean; items: AlertItem[] };
 
 export default function AlertsPage() {
   const qc = useQueryClient();
-  const [form, setForm] = useState<{ symbol: string; price: string }>({ symbol: "", price: "" });
+  const [form, setForm] = useState<{
+    symbol: string;
+    type: "price_above" | "price_below";
+    timeframe: "minute" | "day";
+    level: string; // numeric input as string
+    threshold_pct: string; // optional
+    expires_at: string; // ISO string, optional
+  }>({ symbol: "SPY", type: "price_above", timeframe: "minute", level: "", threshold_pct: "", expires_at: "" });
 
-  const list = useQuery({
+  const list = useQuery<AlertsListResp>({
     queryKey: ["alerts"],
-    queryFn: () => apiGet<AlertsList>("/api/v1/alerts/list"),
+    queryFn: () => apiGet("/api/v1/alerts/list"),
   });
 
   const create = useMutation({
     mutationFn: async () => {
-      const priceNum = Number(form.price);
-      if (!form.symbol || Number.isNaN(priceNum)) throw new Error("Enter symbol and numeric price");
-      await apiPost("/api/v1/alerts/set", { symbol: form.symbol, level: priceNum, note: "dashboard" });
+      const value = Number(form.level);
+      const pct = form.threshold_pct ? Number(form.threshold_pct) : undefined;
+      if (!form.symbol || Number.isNaN(value)) throw new Error("Enter symbol and numeric level");
+      await apiPost("/api/v1/alerts/set", {
+        symbol: form.symbol.toUpperCase(),
+        timeframe: form.timeframe,
+        condition: { type: form.type, value, threshold_pct: pct },
+        expires_at: form.expires_at || undefined,
+      });
     },
     onSuccess: () => {
-      setForm({ symbol: "", price: "" });
+      setForm((f) => ({ ...f, level: "", threshold_pct: "", expires_at: "" }));
       qc.invalidateQueries({ queryKey: ["alerts"] });
     },
   });
 
+  const del = useMutation({
+    mutationFn: async (id: number) => apiPost(`/api/v1/alerts/delete/${id}`, {}),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["alerts"] }),
+  });
+
   return (
-    <main style={{ padding: 20, fontFamily: "system-ui, sans-serif" }}>
-      <h1>Alerts</h1>
+    <main className="container">
+      <h1 style={{ marginBottom: 12 }}>Alerts</h1>
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
-        <input
-          value={form.symbol}
-          onChange={(e) => setForm({ ...form, symbol: e.target.value.toUpperCase() })}
-          placeholder="Symbol"
-        />
-        <input
-          value={form.price}
-          onChange={(e) => setForm({ ...form, price: e.target.value })}
-          placeholder="Price"
-          inputMode="decimal"
-        />
-        <button onClick={() => create.mutate()} disabled={create.isPending}>
-          {create.isPending ? "Creating…" : "Create"}
-        </button>
+      <section className="card" style={{ marginBottom: 12 }}>
+        <div style={{ fontWeight: 600, marginBottom: 6 }}>Create Alert</div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <input
+            value={form.symbol}
+            onChange={(e) => setForm({ ...form, symbol: e.target.value.toUpperCase() })}
+            placeholder="Symbol"
+            className="input"
+            style={{ width: 100 }}
+          />
+          <select className="input" value={form.type} onChange={(e) => setForm({ ...form, type: e.target.value as any })} style={{ width: 160 }}>
+            <option value="price_above">Price above</option>
+            <option value="price_below">Price below</option>
+          </select>
+          <select className="input" value={form.timeframe} onChange={(e) => setForm({ ...form, timeframe: e.target.value as any })} style={{ width: 120 }}>
+            <option value="minute">Minute</option>
+            <option value="day">Day</option>
+          </select>
+          <input
+            value={form.level}
+            onChange={(e) => setForm({ ...form, level: e.target.value })}
+            placeholder="Level (price)"
+            className="input"
+            inputMode="decimal"
+            style={{ width: 140 }}
+          />
+          <input
+            value={form.threshold_pct}
+            onChange={(e) => setForm({ ...form, threshold_pct: e.target.value })}
+            placeholder="Threshold % (opt)"
+            className="input"
+            inputMode="decimal"
+            style={{ width: 160 }}
+          />
+          <input
+            value={form.expires_at}
+            onChange={(e) => setForm({ ...form, expires_at: e.target.value })}
+            placeholder="Expiry ISO (opt)"
+            className="input"
+            style={{ width: 200 }}
+          />
+          <button onClick={() => create.mutate()} disabled={create.isPending}>{create.isPending ? "Creating…" : "Create"}</button>
+        </div>
+        <div className="small" style={{ marginTop: 6, opacity: 0.75 }}>
+          Tip: Use threshold % to account for minor overshoots; leave blank to default to exact level.
+        </div>
+      </section>
+
+      <section className="card">
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div style={{ fontWeight: 600 }}>Active Alerts</div>
+          {list.isFetching ? <div className="small" style={{ opacity: 0.75 }}>Refreshing…</div> : null}
+        </div>
+        {list.isPending && <div className="small">Loading alerts…</div>}
+        {list.error && <div className="small" style={{ color: "#ffb4b4" }}>Error: {(list.error as Error).message}</div>}
+        {list.data?.items?.length ? (
+          <table className="table" style={{ marginTop: 8 }}>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Symbol</th>
+                <th>Timeframe</th>
+                <th>Type</th>
+                <th>Level</th>
+                <th>Thresh %</th>
+                <th>Expires</th>
+                <th>Created</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.data.items.map((a) => (
+                <tr key={a.id}>
+                  <td>{a.id}</td>
+                  <td>{a.symbol}</td>
+                  <td>{a.timeframe ?? "—"}</td>
+                  <td>{a.condition?.type ?? "—"}</td>
+                  <td>{a.condition?.value ?? "—"}</td>
+                  <td>{a.condition?.threshold_pct ?? "—"}</td>
+                  <td>{a.expires_at ?? "—"}</td>
+                  <td>{a.created_at ?? "—"}</td>
+                  <td><button className="secondary" onClick={() => del.mutate(a.id)} disabled={del.isPending}>Delete</button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : list.isSuccess ? (
+          <div className="small" style={{ marginTop: 8 }}>No alerts yet.</div>
+        ) : null}
+      </section>
+
+      <div className="small" style={{ marginTop: 8, opacity: 0.75 }}>
+        Discord forwarding can be enabled in Settings when a webhook is configured and types are allowed.
       </div>
-
-      {list.isPending && <div>Loading alerts…</div>}
-      {list.error && <div style={{ color: "crimson" }}>Error: {(list.error as Error).message}</div>}
-      {list.data?.data?.alerts?.length ? (
-        <ul>
-          {list.data.data.alerts.map((a, i) => (
-            <li key={i}><code>{JSON.stringify(a)}</code></li>
-          ))}
-        </ul>
-      ) : list.isSuccess ? (
-        <div>No alerts yet.</div>
-      ) : null}
     </main>
   );
 }

--- a/trading-dashboard/app/api/proxy/route.ts
+++ b/trading-dashboard/app/api/proxy/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
+// Run this lightweight proxy on the Edge runtime to minimize
+// Serverless Function bundle size and avoid the 250 MB limit.
+export const runtime = "edge";
+
 // Proxies requests to the backend API to avoid CORS in the browser.
 // Reads base URL and optional API key from env.
 
@@ -59,4 +63,3 @@ export async function POST(req: NextRequest) {
   const buf = await res.arrayBuffer();
   return new NextResponse(buf, { status: res.status, headers: res.headers });
 }
-

--- a/trading-dashboard/app/api/proxy/route.ts
+++ b/trading-dashboard/app/api/proxy/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Proxies requests to the backend API to avoid CORS in the browser.
+// Reads base URL and optional API key from env.
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || "";
+
+function join(base: string, path: string) {
+  if (!base) return path;
+  const b = base.replace(/\/$/, "");
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${b}${p}`;
+}
+
+export async function GET(req: NextRequest) {
+  const path = req.nextUrl.searchParams.get("path") || "/";
+  const url = new URL(join(API_BASE, path));
+  // forward query params except `path`
+  req.nextUrl.searchParams.forEach((v, k) => {
+    if (k !== "path") url.searchParams.set(k, v);
+  });
+
+  const res = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      ...(API_KEY ? { "X-API-Key": API_KEY } : {}),
+      // Propagate content-type for JSON endpoints
+      "Accept": "application/json",
+    },
+    cache: "no-store",
+  });
+  const body = await res.arrayBuffer();
+  return new NextResponse(body, {
+    status: res.status,
+    headers: res.headers,
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const path = req.nextUrl.searchParams.get("path") || "/";
+  const url = new URL(join(API_BASE, path));
+  // forward query params except `path`
+  req.nextUrl.searchParams.forEach((v, k) => {
+    if (k !== "path") url.searchParams.set(k, v);
+  });
+
+  const body = await req.arrayBuffer();
+  const res = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": req.headers.get("content-type") || "application/json",
+      ...(API_KEY ? { "X-API-Key": API_KEY } : {}),
+      "Accept": "application/json",
+    },
+    body,
+    cache: "no-store",
+  });
+  const buf = await res.arrayBuffer();
+  return new NextResponse(buf, { status: res.status, headers: res.headers });
+}
+

--- a/trading-dashboard/app/coach/page.tsx
+++ b/trading-dashboard/app/coach/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { apiPost } from "@/src/lib/api";
+
+type Msg = { role: "user"|"assistant"|"system"|"tool"; content: string; tool_call_id?: string; name?: string };
+
+export default function CoachPage() {
+  const [messages, setMessages] = useState<Msg[]>([
+    { role: "system", content: "Coach me on intraday opportunities; be concise and risk-aware." },
+  ]);
+  const [input, setInput] = useState("");
+  const [pending, setPending] = useState(false);
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || pending) return;
+    const next = [...messages, { role: "user", content: text } as Msg];
+    setMessages(next);
+    setInput("");
+    setPending(true);
+    try {
+      const resp = await apiPost("/api/v1/coach/chat", { messages: next });
+      const content = (resp?.content ?? "").toString();
+      setMessages([...next, { role: "assistant", content }]);
+    } catch (e: any) {
+      setMessages([...next, { role: "assistant", content: `Error: ${e?.message ?? e}` }]);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <main className="container">
+      <h1 style={{ marginBottom: 12 }}>AI Coach</h1>
+      <div className="card" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minHeight: 240 }}>
+          {messages.filter(m => m.role !== "system").map((m, i) => (
+            <div key={i} className="card" style={{ margin: 0, background: m.role === "user" ? "#1e1e1e" : "#141414" }}>
+              <div className="small" style={{ opacity: .7, marginBottom: 4 }}>{m.role}</div>
+              <div style={{ whiteSpace: "pre-wrap" }}>{m.content}</div>
+            </div>
+          ))}
+          {pending && <div className="small">Thinking…</div>}
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            className="input"
+            placeholder="Ask the coach (e.g., Best scalp setups right now?)"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") send(); }}
+          />
+          <button onClick={send} disabled={pending}>Send</button>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/trading-dashboard/app/journal/page.tsx
+++ b/trading-dashboard/app/journal/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiGet, apiPost } from "@/src/lib/api";
+import { useState } from "react";
+
+type Entry = { id: number; symbol: string; r?: number; side?: string; notes?: string; created_at: string };
+
+export default function JournalPage() {
+  const qc = useQueryClient();
+  const [symbol, setSymbol] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const list = useQuery({
+    queryKey: ["journal"],
+    queryFn: async (): Promise<Entry[]> => {
+      const res = await apiGet("/api/v1/journal/list?limit=200");
+      return res?.items ?? [];
+    },
+  });
+
+  const create = useMutation({
+    mutationFn: async () => apiPost("/api/v1/journal/create", { symbol, notes }),
+    onSuccess: () => { setSymbol(""); setNotes(""); qc.invalidateQueries({queryKey:["journal"]}); },
+  });
+
+  return (
+    <main className="container">
+      <h1 style={{marginBottom:12}}>Journal</h1>
+      <section className="card" style={{marginBottom:12}}>
+        <div style={{display:"flex", gap:8}}>
+          <input className="input" placeholder="Symbol" value={symbol} onChange={e=>setSymbol(e.target.value.toUpperCase())} />
+          <input className="input" placeholder="Notes" value={notes} onChange={e=>setNotes(e.target.value)} />
+          <button onClick={()=> create.mutate()} disabled={!symbol || !notes}>Add</button>
+        </div>
+      </section>
+      <section className="card">
+        <table className="table">
+          <thead><tr><th>Time</th><th>Symbol</th><th>Side</th><th>R</th><th>Notes</th></tr></thead>
+          <tbody>
+            {(list.data ?? []).map(e => (
+              <tr key={e.id}><td>{new Date(e.created_at).toLocaleString()}</td><td>{e.symbol}</td><td>{e.side ?? '—'}</td><td>{e.r ?? '—'}</td><td>{e.notes ?? ''}</td></tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  );
+}
+

--- a/trading-dashboard/app/layout.tsx
+++ b/trading-dashboard/app/layout.tsx
@@ -1,4 +1,5 @@
 import QueryProvider from "@/src/lib/query-provider";
+import BootSnapshot from "@/src/components/BootSnapshot";
 import "./globals.css";
 import { Toaster } from "sonner";
 
@@ -13,7 +14,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <a href="/admin">Admin</a>
         </div>
         <div className="container">
-          <QueryProvider>{children}</QueryProvider>
+          <QueryProvider>
+            <BootSnapshot />
+            {children}
+          </QueryProvider>
           <Toaster position="top-right" />
         </div>
       </body>

--- a/trading-dashboard/app/page.tsx
+++ b/trading-dashboard/app/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiGet, apiPost } from "@/src/lib/api";
 import { connectWS } from "@/src/lib/ws";
-import { useWS, usePrices } from "@/src/lib/store";
+import { useWS, usePrices, useRisk } from "@/src/lib/store";
 import { toast } from "sonner";
 import NewsPanel from "@/components/NewsPanel";
 import AlertsPanel from "@/components/AlertsPanel";
@@ -32,6 +32,7 @@ export default function Page() {
   const [ticker, setTicker] = useState("SPY");
   const connected = useWS();
   const prices = usePrices();
+  const risk = useRisk();
 
   // per-contract inputs: { [contractSymbol]: {entry, stop} }
   const [inputs, setInputs] = useState<Record<string, {entry:string; stop:string}>>({});
@@ -70,8 +71,12 @@ export default function Page() {
   });
 
   const alertMut = useMutation({
-    mutationFn: (args: {symbol:string; level:number}) =>
-      apiPost("/api/v1/alerts/set", { symbol: args.symbol, timeframe: "minute", condition: { type: "price_above", value: args.level } })
+    mutationFn: (args: {symbol:string; timeframe?: 'minute'|'day'; type: 'price_above'|'price_below'; value:number; threshold_pct?: number}) =>
+      apiPost("/api/v1/alerts/set", {
+        symbol: args.symbol,
+        timeframe: args.timeframe || 'minute',
+        condition: { type: args.type, value: args.value, threshold_pct: args.threshold_pct },
+      })
   });
 
   const setInput = (k: string, field: "entry"|"stop", v: string) =>
@@ -90,6 +95,13 @@ export default function Page() {
       <div className="small" style={{marginBottom:8, display:"flex", gap:12, alignItems:"center", flexWrap:"wrap"}}>
         <span>WS: {connected ? "Connected" : "Disconnected"}</span>
         <span>Price {ticker}: {prices?.[ticker] !== undefined ? Number(prices[ticker]).toFixed(2) : "—"}</span>
+        {risk ? (
+          <span>
+            Risk — daily R: {Number(risk?.daily_r ?? 0).toFixed(2)} · positions: {risk?.concurrent ?? 0}
+            {risk?.breach_daily_r ? " · DAILY BREACH" : ""}
+            {risk?.breach_concurrent ? " · CONCURRENT BREACH" : ""}
+          </span>
+        ) : null}
       </div>
 
       <section className="card" style={{marginBottom:12}}>
@@ -168,11 +180,15 @@ export default function Page() {
                       sizing.mutate({ symbol: ticker, side: side==="call" ? "long" : "short", risk_R: 1, per_unit_risk });
                     }}>Size It</button>
 
-                    <button className="secondary" onClick={()=>{
-                      // simple price alert at the entry level
-                      if(!entry){ toast("Enter an entry to set an alert level"); return; }
-                      alertMut.mutate({ symbol: ticker, level: Number(entry) });
-                    }}>Set Alert</button>
+                    <InlineAlertCreator
+                      symbol={ticker}
+                      entry={entry}
+                      stop={stop}
+                      onCreate={(type, thresholdPct, level)=>{
+                        if(!entry){ toast("Enter an entry first"); return; }
+                        alertMut.mutate({ symbol: ticker, type, value: level, threshold_pct: thresholdPct });
+                      }}
+                    />
                   </div>
                 </div>
               );
@@ -208,22 +224,7 @@ export default function Page() {
             </div>
           </div>
 
-          <div className="card" style={{flex:"1 1 320px"}}>
-            <div style={{display:"flex", justifyContent:"space-between", alignItems:"center"}}>
-              <div style={{fontWeight:600, marginBottom:6}}>Confidence & Analysis</div>
-              <button className="secondary" onClick={() => analyze.mutate(ticker)} disabled={analyze.isPending}>Analyze</button>
-            </div>
-            <div className="small" style={{marginTop:6}}>
-              {analyze.isPending ? "Analyzing…" : analyze.isError ? String(analyze.error) : analyze.data ? (
-                <>
-                  <div style={{marginBottom:6}}>
-                    <strong>Strategy:</strong> {analyze.data?.chosen_strategy || analyze.data?.input?.strategy_id || "auto"}
-                  </div>
-                  <pre style={{whiteSpace:"pre-wrap"}}>{JSON.stringify(analyze.data?.analysis ?? analyze.data, null, 2)}</pre>
-                </>
-              ) : "—"}
-            </div>
-          </div>
+          <ConfidenceCard ticker={ticker} analyze={analyze} />
         </div>
       </section>
 
@@ -237,5 +238,99 @@ export default function Page() {
         </div>
       </div>
     </main>
+  );
+}
+
+// --- UI subcomponents ---
+
+function bandMeta(score?: number): { label: string; color: string } {
+  const s = typeof score === 'number' ? score : -1;
+  if (s >= 70) return { label: 'Favorable', color: '#16a34a' };
+  if (s >= 50) return { label: 'Mixed', color: '#eab308' };
+  if (s >= 0) return { label: 'Unfavorable', color: '#ef4444' };
+  return { label: '—', color: '#64748b' };
+}
+
+function ConfidenceCard({ ticker, analyze }: { ticker: string; analyze: any }) {
+  const data = analyze?.data;
+  const analysis = data?.analysis || null;
+  const score: number | undefined = analysis?.score;
+  const meta = bandMeta(score);
+  const comps: Record<string, number> = analysis?.components || {};
+  const rationale: string | undefined = analysis?.rationale;
+  const freshness = data?.context?.data_freshness_sec;
+
+  return (
+    <div className="card" style={{flex:"1 1 320px"}}>
+      <div style={{display:"flex", justifyContent:"space-between", alignItems:"center"}}>
+        <div style={{fontWeight:600, marginBottom:6}}>Confidence & Analysis</div>
+        <button className="secondary" onClick={() => analyze.mutate(ticker)} disabled={analyze.isPending}>Analyze</button>
+      </div>
+      <div className="small" style={{marginTop:6}}>
+        {analyze.isPending ? "Analyzing…" : analyze.isError ? String(analyze.error) : analysis ? (
+          <>
+            <div style={{display:"flex", alignItems:"center", gap:10, marginBottom:8}}>
+              <div style={{display:"inline-flex", alignItems:"center", gap:8, background:"rgba(255,255,255,0.04)", border:"1px solid var(--border)", borderRadius:12, padding:"6px 10px"}}>
+                <div style={{fontSize:"1.2rem", fontWeight:800}}>{Math.round(score ?? 0)}</div>
+                <div style={{color: meta.color, fontWeight:700}}>{meta.label}</div>
+              </div>
+              <div style={{opacity:.75}}>freshness: {freshness !== undefined ? `${freshness}s` : '—'}</div>
+            </div>
+
+            <div className="chiprow" style={{marginBottom:8}}>
+              {Object.keys(comps).length ? (
+                Object.entries(comps).map(([k,v]) => (
+                  <span key={k} className="chip" title={k}>
+                    {k.replace(/_/g,' ')}: {v as number >= 0 ? `+${v}` : v}
+                  </span>
+                ))
+              ) : (
+                <span className="small">No components available.</span>
+              )}
+            </div>
+
+            {rationale ? (<div className="small" style={{whiteSpace:'pre-wrap'}}>{rationale}</div>) : null}
+          </>
+        ) : "—"}
+      </div>
+    </div>
+  );
+}
+
+function InlineAlertCreator({ symbol, entry, stop, onCreate }:{ symbol: string; entry: string; stop: string; onCreate: (type: 'price_above'|'price_below', thresholdPct: number|undefined, level: number)=>void }) {
+  const [atype, setAtype] = useState<'price_above'|'price_below'>('price_above');
+  const [thresh, setThresh] = useState<string>(""); // % optional
+
+  const computeLevel = () => {
+    const e = Number(entry);
+    const s = Number(stop);
+    if (!entry || !stop || Number.isNaN(e) || Number.isNaN(s)) return NaN;
+    const perR = Math.abs(e - s);
+    const pct = Number(thresh);
+    if (!Number.isNaN(pct) && pct > 0) {
+      const offs = (e * pct) / 100;
+      return atype === 'price_above' ? e + offs : e - offs;
+    }
+    return atype === 'price_above' ? e + perR : e - perR;
+  };
+
+  const level = computeLevel();
+
+  return (
+    <div style={{display:'inline-flex', gap:8, alignItems:'center', flexWrap:'wrap'}}>
+      <select value={atype} onChange={(e)=> setAtype(e.target.value as any)}>
+        <option value="price_above">Alert above</option>
+        <option value="price_below">Alert below</option>
+      </select>
+      <input className="input" placeholder="threshold % (opt)" style={{width:120}}
+        value={thresh} onChange={(e)=> setThresh(e.target.value)} inputMode="decimal" />
+      <button className="secondary" onClick={()=>{
+        if (!entry) { toast("Enter an entry first"); return; }
+        const lvl = computeLevel();
+        if (!Number.isFinite(lvl)) { toast("Provide stop or threshold %"); return; }
+        const pct = thresh ? Number(thresh) : undefined;
+        onCreate(atype, pct, Number(lvl.toFixed(4)));
+      }}>Set Alert {Number.isFinite(level) ? `@ ${level.toFixed(2)}` : ''}</button>
+    </div>
   );
 }

--- a/trading-dashboard/components/AlertsPanel.tsx
+++ b/trading-dashboard/components/AlertsPanel.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useAlerts } from "@/src/lib/store";
+
+export default function AlertsPanel() {
+  const alerts = useAlerts();
+  return (
+    <section className="card">
+      <div style={{fontWeight:600, marginBottom:6}}>Alerts</div>
+      {alerts.length === 0 ? (
+        <div className="small">No alerts.</div>
+      ) : (
+        <ul style={{display:"flex", flexDirection:"column", gap:8}}>
+          {alerts.map((a, idx) => (
+            <li key={idx} className="card" style={{margin:0}}>
+              <div className="small" style={{opacity:.7, marginBottom:4}}>{a.level || 'info'}</div>
+              <div>{a.msg}</div>
+              {/* Action chips could open Coach or trigger order flows; keep simple */}
+              <div style={{display:"flex", gap:8, marginTop:8}}>
+                <button className="secondary" onClick={() => window.dispatchEvent(new CustomEvent('coach:prompt', { detail: `Given this alert: ${a.msg}. Propose next best action with confidence %.` }))}>Ask Coach</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+

--- a/trading-dashboard/components/NewsPanel.tsx
+++ b/trading-dashboard/components/NewsPanel.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { coachChat, CoachMsg } from "@/src/lib/coach";
+
+type Props = { symbols: string[] };
+
+export default function NewsPanel({ symbols }: Props) {
+  const [text, setText] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const fetchNews = async () => {
+    setLoading(true);
+    try {
+      const sys: CoachMsg = { role: "system", content: "You browse the web and return concise trading-relevant news, upcoming earnings, and economic events. Always include confidence % per item." };
+      const user: CoachMsg = { role: "user", content: `For ${symbols.join(", ")}, summarize: (1) top headlines that can move price now, (2) next 7 days earnings for any of them, (3) today's/tomorrow's key econ prints. For each item: symbol(s), why it matters in 1 line, confidence %.` };
+      const resp = await coachChat([sys, user]);
+      setText(resp?.content || "");
+    } catch (e: any) {
+      setText(`Error: ${e?.message ?? e}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchNews(); /* eslint-disable-next-line */ }, [symbols.join(",")]);
+
+  return (
+    <section className="card">
+      <div style={{display:"flex", justifyContent:"space-between", alignItems:"center"}}>
+        <div style={{fontWeight:600}}>News & Events</div>
+        <button className="secondary" onClick={fetchNews} disabled={loading}>{loading?"Refreshing…":"Refresh"}</button>
+      </div>
+      <div className="small" style={{whiteSpace:"pre-wrap", marginTop:8}}>{text || "—"}</div>
+    </section>
+  );
+}
+

--- a/trading-dashboard/next.config.cjs
+++ b/trading-dashboard/next.config.cjs
@@ -2,6 +2,22 @@
 const nextConfig = {
   experimental: {
     appDir: true,
+    // Reduce serverless bundle size by excluding non-runtime files from tracing
+    outputFileTracingExcludes: {
+      '*': [
+        '**/*.map',
+        '**/__tests__/**',
+        '**/tests/**',
+        '**/docs/**',
+        '**/.github/**',
+        '**/.vscode/**',
+        '**/coverage/**',
+      ],
+    },
   },
+  // Avoid bundling image optimizer (not needed for this app)
+  images: { unoptimized: true },
+  // Skip ESLint during build in Vercel for faster deploys (CI should lint)
+  eslint: { ignoreDuringBuilds: true },
 };
 module.exports = nextConfig;

--- a/trading-dashboard/src/components/BootSnapshot.tsx
+++ b/trading-dashboard/src/components/BootSnapshot.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import { apiGet } from "@/src/lib/api";
+import { wsStore } from "@/src/lib/store";
+
+export default function BootSnapshot() {
+  useEffect(() => {
+    (async () => {
+      try {
+        const s: any = await apiGet("/api/v1/stream/state");
+        const positions = (s?.positions) ?? [];
+        const orders = (s?.orders) ?? [];
+        const risk = s?.risk ?? null;
+        wsStore.setState({ positions, orders, risk });
+      } catch {
+        // ignore snapshot errors in UI boot
+      }
+    })();
+  }, []);
+  return null;
+}
+

--- a/trading-dashboard/src/lib/api.ts
+++ b/trading-dashboard/src/lib/api.ts
@@ -12,12 +12,15 @@ async function handle(res: Response) {
 }
 
 export async function apiGet(path: string) {
-  const res = await fetch(`${BASE}${path}`, { cache: "no-store" });
+  // Use local proxy to avoid cross-origin CORS issues in the browser.
+  const proxied = `/api/proxy?path=${encodeURIComponent(path)}`;
+  const res = await fetch(proxied, { cache: "no-store" });
   return handle(res);
 }
 
 export async function apiPost(path: string, body: any) {
-  const res = await fetch(`${BASE}${path}`, {
+  const proxied = `/api/proxy?path=${encodeURIComponent(path)}`;
+  const res = await fetch(proxied, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body ?? {})

--- a/trading-dashboard/src/lib/coach.ts
+++ b/trading-dashboard/src/lib/coach.ts
@@ -1,12 +1,14 @@
 export type CoachMsg = { role: 'system'|'user'|'assistant'|'tool'; content: string; tool_call_id?: string; name?: string };
 
 export async function coachChat(messages: CoachMsg[]) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE || ''}/api/v1/coach/chat`, {
+  // Proxy to the backend to avoid CORS.
+  const url = `/api/proxy?path=${encodeURIComponent('/api/v1/coach/chat')}`;
+  const res = await fetch(url, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ messages }),
+    cache: 'no-store',
   });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
-

--- a/trading-dashboard/src/lib/coach.ts
+++ b/trading-dashboard/src/lib/coach.ts
@@ -1,0 +1,12 @@
+export type CoachMsg = { role: 'system'|'user'|'assistant'|'tool'; content: string; tool_call_id?: string; name?: string };
+
+export async function coachChat(messages: CoachMsg[]) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE || ''}/api/v1/coach/chat`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ messages }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+

--- a/trading-dashboard/src/lib/store.ts
+++ b/trading-dashboard/src/lib/store.ts
@@ -46,6 +46,9 @@ export function useRisk() {
 export function useAlerts() {
   return useSyncExternalStore(subscribe, () => state.alerts);
 }
+export function usePrices() {
+  return useSyncExternalStore(subscribe, () => state.prices);
+}
 
 export const wsStore = {
   setState,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "trading-dashboard/package.json", "use": "@vercel/next" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "trading-dashboard/$1" }
+  ]
+}
+


### PR DESCRIPTION
This PR updates the dashboard/backend to improve confidence surfacing and reduce Vercel bundle size.\n\nHighlights\n- Coach: add compose.analyze tool and prompt updates to include 0–100 confidence + rationale.\n- Plan API: add rr_bands (0.5R/1R/2R) and a concise NL summary.\n- Alerts: add update route to complete CRUD.\n- Next.js build: move /app/api/proxy to Edge runtime and exclude tests/docs/maps via next.config to avoid 250MB Serverless limit.\n- Docs: PROGRESS.md and DEPLOYMENT.md; ROADMAP reviewed with session banner.\n\nBackend tests: 43 passed locally.\nAfter merge, Vercel should build only trading-dashboard/ and use the Edge proxy; verify /api/proxy?path=/api/v1/diag/health and WS connectivity.