### PR TITLE
UI: Narrator + Position Coach + ConfidenceCard v2 + Premarket + News

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -178,6 +178,7 @@ _mount("app.routers.coach_stream", secure=True)  # SSE narrator stream
 _mount("app.routers.journal", secure=True)  # journal CRUD
 _mount("app.routers.trades", secure=True)  # trade endpoints if present
 _mount("app.routers.settings", secure=True)  # admin settings CRUD
+_mount("app.routers.market", secure=True)  # market bars
 
 # auth + news
 _mount("app.routers.auth")  # ws-token mint

--- a/app/routers/market.py
+++ b/app/routers/market.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+
+router = APIRouter(prefix="/market", tags=["market"])
+
+POLYGON_API_KEY = (os.getenv("POLYGON_API_KEY") or "").strip()
+POLYGON_BASE = "https://api.polygon.io"
+
+
+@router.get("/bars")
+async def get_bars(symbol: str = Query(..., min_length=1), tf: str = Query("1m")) -> Dict[str, Any]:
+    """Return recent OHLCV bars for a symbol.
+
+    Query params:
+      - symbol: ticker symbol
+      - tf: timeframe: "1m" or "5m" or "day"
+    """
+    if not POLYGON_API_KEY:
+        raise HTTPException(status_code=500, detail="POLYGON_API_KEY not configured")
+    tf = (tf or "1m").lower()
+    if tf not in {"1m", "5m", "day"}:
+        raise HTTPException(status_code=400, detail="invalid tf (1m|5m|day)")
+    timespan = "minute" if tf in {"1m", "5m"} else "day"
+    mult = 1 if tf in {"1m", "day"} else 5
+
+    # choose a reasonable lookback
+    now = datetime.now(timezone.utc)
+    start = now - (timedelta(days=7) if timespan == "minute" else timedelta(days=200))
+    url = f"{POLYGON_BASE}/v2/aggs/ticker/{symbol.upper()}/range/{mult}/{timespan}/{start.date()}/{now.date()}"
+    params = {"sort": "asc", "limit": 5000, "apiKey": POLYGON_API_KEY}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.get(url, params=params)
+        if r.status_code != 200:
+            raise HTTPException(status_code=r.status_code, detail=r.text)
+        data = r.json() or {}
+        items: List[Dict[str, Any]] = []
+        for b in (data.get("results") or []):
+            items.append({
+                "t": b.get("t"),
+                "o": b.get("o"),
+                "h": b.get("h"),
+                "l": b.get("l"),
+                "c": b.get("c"),
+                "v": b.get("v"),
+            })
+        return {"ok": True, "symbol": symbol.upper(), "tf": tf, "items": items[-500:]}
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ Last reviewed: 2025-09-14
 
 ## M1 — Live Prices & Alerts
 - [x] Polygon WS client publishes `price` for watchlist symbols.
-- [ ] Alerts CRUD with validation; list/create/update/delete.  (update route pending)
+- [x] Alerts CRUD with validation; list/create/update/delete.
 - [x] Alert poller triggers via Polygon HTTP; creates `AlertTrigger` rows; WS `alert` fan‑out.
 
 ## M2 — Planning & Sizing
@@ -45,15 +45,13 @@ Last reviewed: 2025-09-14
 - [x] Y2 — Snapshot on connect: `/api/v1/stream/state` to seed frontend before ticks. (implemented)
 - [x] Y3 — Observability: request IDs, structured JSON logs, timing for broker/chatdata.
 - [x] Y4 — SSE backpressure: 3s cadence and significant‑delta gating.
-- [ ] Y5 — Rate limiting: per‑IP sliding window on `/coach/stream` and `/news`.
 - [x] Y5 — Rate limiting: per‑IP sliding window on `/coach/stream` and `/news`.
 - [x] Y6 — Broker/journal auditing: persist placed orders + narrator guidance.
-- [ ] R5 — OCO/Bracket (Tradier): preview/place entry+SL+TP and journal summary.
 - [x] R5 — OCO/Bracket (Tradier): preview/place entry+SL+TP and journal summary.
 ## M5 — Discord Alerts
-- [ ] Settings: webhook URL, enable toggle, allowed alert types (e.g., price_above, price_below, risk).
-- [ ] Poller forwards triggers to Discord when enabled and type matches.
-- [ ] Optional: risk breach alerts forwarded from risk engine.
+- [x] Settings: webhook URL, enable toggle, allowed alert types (e.g., price_above, price_below, risk).
+- [x] Poller forwards triggers to Discord when enabled and type matches.
+- [x] Risk breach alerts forwarded from risk engine.
 
 Status notes
 - Frontend dashboard + WS live; price/risk/alerts propagate over WS.

--- a/trading-dashboard/app/api/proxy/route.ts
+++ b/trading-dashboard/app/api/proxy/route.ts
@@ -34,11 +34,8 @@ export async function GET(req: NextRequest) {
     },
     cache: "no-store",
   });
-  const body = await res.arrayBuffer();
-  return new NextResponse(body, {
-    status: res.status,
-    headers: res.headers,
-  });
+  // Stream pass-through for SSE and other streaming responses
+  return new NextResponse(res.body, { status: res.status, headers: res.headers });
 }
 
 export async function POST(req: NextRequest) {

--- a/trading-dashboard/app/coach/page.tsx
+++ b/trading-dashboard/app/coach/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { apiPost } from "@/src/lib/api";
+import ConfidenceCard from "@/components/ConfidenceCard";
 
 type Msg = { role: "user"|"assistant"|"system"|"tool"; content: string; tool_call_id?: string; name?: string };
 
@@ -11,6 +12,15 @@ export default function CoachPage() {
   ]);
   const [input, setInput] = useState("");
   const [pending, setPending] = useState(false);
+  const [symbol, setSymbol] = useState("SPY");
+  const [analysis, setAnalysis] = useState<any|null>(null);
+
+  const analyze = async () => {
+    try {
+      const res = await apiPost("/api/v1/compose-and-analyze", { symbol, strategy_id: "auto" });
+      setAnalysis(res?.analysis || null);
+    } catch (e) { setAnalysis(null); }
+  };
 
   const send = async () => {
     const text = input.trim();
@@ -33,6 +43,31 @@ export default function CoachPage() {
   return (
     <main className="container">
       <h1 style={{ marginBottom: 12 }}>AI Coach</h1>
+      <section className="card" style={{marginBottom:12}}>
+        <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
+          <div style={{fontWeight:600}}>Context</div>
+          <div style={{display:'flex', gap:8}}>
+            <input className="input" style={{width:120}} value={symbol} onChange={(e)=> setSymbol(e.target.value.toUpperCase())} />
+            <button className="secondary" onClick={analyze}>Analyze</button>
+          </div>
+        </div>
+        {analysis ? (
+          <div style={{marginTop:8}}>
+            <ConfidenceCard
+              score={Number(analysis?.score ?? 0)}
+              band={String(analysis?.band ?? 'mixed')}
+              components={{
+                ATR: Number(analysis?.components?.atr_regime ?? 0),
+                VWAP: Number(analysis?.components?.vwap_posture ?? analysis?.components?.vwap_support ?? 0),
+                EMAs: Number(analysis?.components?.ema_stack ?? 0),
+                Flow: Number((analysis?.components?.flow ?? 0) + (analysis?.components?.momentum_hint ?? 0)),
+                Liquidity: Number(analysis?.components?.liquidity ?? 0),
+                Vol: Number(analysis?.components?.vol_context ?? 0),
+              }}
+            />
+          </div>
+        ) : <div className="small" style={{opacity:.7, marginTop:6}}>Analyze a symbol to view confidence and signals.</div>}
+      </section>
       <div className="card" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         <div style={{ display: "flex", flexDirection: "column", gap: 8, minHeight: 240 }}>
           {messages.filter(m => m.role !== "system").map((m, i) => (
@@ -57,4 +92,3 @@ export default function CoachPage() {
     </main>
   );
 }
-

--- a/trading-dashboard/app/globals.css
+++ b/trading-dashboard/app/globals.css
@@ -50,3 +50,7 @@ pre,code,kbd,samp{
   border-radius:8px;
   padding:8px 10px;
 }
+
+/* mobile helpers */
+.mobile-only{ display:block }
+@media (min-width: 640px){ .mobile-only{ display:none } }

--- a/trading-dashboard/app/layout.tsx
+++ b/trading-dashboard/app/layout.tsx
@@ -4,6 +4,7 @@ import BootSnapshot from "@/src/components/BootSnapshot";
 import "./globals.css";
 import { Toaster } from "sonner";
 import Link from "next/link";
+import CommandPalette from "@/components/CommandPalette";
 
 export const metadata = { title: "Trading Assistant Dashboard" };
 
@@ -19,6 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <QueryProvider>
             <BootSnapshot />
             {children}
+            <CommandPalette />
           </QueryProvider>
           <Toaster position="top-right" />
         </div>

--- a/trading-dashboard/app/layout.tsx
+++ b/trading-dashboard/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { Toaster } from "sonner";
 import Link from "next/link";
 import CommandPalette from "@/components/CommandPalette";
+import AskCoachWidget from "@/components/AskCoachWidget";
 
 export const metadata = { title: "Trading Assistant Dashboard" };
 
@@ -21,6 +22,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <BootSnapshot />
             {children}
             <CommandPalette />
+            <AskCoachWidget />
           </QueryProvider>
           <Toaster position="top-right" />
         </div>

--- a/trading-dashboard/app/page.tsx
+++ b/trading-dashboard/app/page.tsx
@@ -8,6 +8,9 @@ import { useWS, usePrices, useRisk } from "@/src/lib/store";
 import { toast } from "sonner";
 import NewsPanel from "@/components/NewsPanel";
 import AlertsPanel from "@/components/AlertsPanel";
+import NarrativeTicker from "@/components/NarrativeTicker";
+import PositionCoach from "@/components/PositionCoach";
+import ConfidenceCardV2 from "@/components/ConfidenceCard";
 
 type WatchlistResp = { ok: boolean; symbols: string[] };
 type Pick = {
@@ -224,7 +227,7 @@ export default function Page() {
             </div>
           </div>
 
-          <ConfidenceCard ticker={ticker} analyze={analyze} />
+          <ConfidencePanel ticker={ticker} analyze={analyze} />
         </div>
       </section>
 
@@ -233,8 +236,21 @@ export default function Page() {
           {/* Reserved for future chart/workspace content */}
         </div>
         <div style={{display:"flex", flexDirection:"column", gap:12}}>
+          <NarrativeTicker symbol={ticker} />
+          <PositionCoach symbol={ticker} />
           <NewsPanel symbols={(wl.data?.symbols ?? [ticker]).slice(0,7)} />
           <AlertsPanel />
+        </div>
+      </div>
+
+      {/* Sticky mobile action bar */}
+      <div style={{position:"fixed", left:0, right:0, bottom:8, display:"flex", gap:8, justifyContent:"center"}}
+        className="mobile-only">
+        <div className="card" style={{display:"flex", gap:8, padding:8}}>
+          <button className="secondary" onClick={()=>alert("Buy ticket (stub)")}>Buy</button>
+          <button className="secondary" onClick={()=>alert("Sell/Close (stub)")}>Sell</button>
+          <button className="secondary" onClick={()=>alert("Alert preset (stub)")}>Alert</button>
+          <button className="secondary" onClick={()=>alert("Ask Coach (stub)")}>Coach</button>
         </div>
       </div>
     </main>
@@ -251,7 +267,7 @@ function bandMeta(score?: number): { label: string; color: string } {
   return { label: '—', color: '#64748b' };
 }
 
-function ConfidenceCard({ ticker, analyze }: { ticker: string; analyze: any }) {
+function ConfidencePanel({ ticker, analyze }: { ticker: string; analyze: any }) {
   const data = analyze?.data;
   const analysis = data?.analysis || null;
   const score: number | undefined = analysis?.score;
@@ -269,6 +285,20 @@ function ConfidenceCard({ ticker, analyze }: { ticker: string; analyze: any }) {
       <div className="small" style={{marginTop:6}}>
         {analyze.isPending ? "Analyzing…" : analyze.isError ? String(analyze.error) : analysis ? (
           <>
+            <div style={{marginBottom:8}}>
+              <ConfidenceCardV2
+                score={score ?? 0}
+                band={meta.label.toLowerCase()}
+                components={{
+                  ATR: Number(comps.atr_regime ?? 0),
+                  VWAP: Number(comps.vwap_posture ?? comps.vwap_support ?? 0),
+                  EMAs: Number(comps.ema_stack ?? 0),
+                  Flow: Number((comps.flow ?? 0) + (comps.momentum_hint ?? 0)),
+                  Liquidity: Number(comps.liquidity ?? 0),
+                  Vol: Number(comps.vol_context ?? 0),
+                }}
+              />
+            </div>
             <div style={{display:"flex", alignItems:"center", gap:10, marginBottom:8}}>
               <div style={{display:"inline-flex", alignItems:"center", gap:8, background:"rgba(255,255,255,0.04)", border:"1px solid var(--border)", borderRadius:12, padding:"6px 10px"}}>
                 <div style={{fontSize:"1.2rem", fontWeight:800}}>{Math.round(score ?? 0)}</div>

--- a/trading-dashboard/app/page.tsx
+++ b/trading-dashboard/app/page.tsx
@@ -11,6 +11,8 @@ import AlertsPanel from "@/components/AlertsPanel";
 import NarrativeTicker from "@/components/NarrativeTicker";
 import PositionCoach from "@/components/PositionCoach";
 import ConfidenceCardV2 from "@/components/ConfidenceCard";
+import LiveChart from "@/components/LiveChart";
+import OrderTicket from "@/components/OrderTicket";
 
 type WatchlistResp = { ok: boolean; symbols: string[] };
 type Pick = {
@@ -33,6 +35,7 @@ function smallNum(n?: number, d: number = 3) {
 export default function Page() {
   const [side, setSide] = useState<"call"|"put">("call");
   const [ticker, setTicker] = useState("SPY");
+  const [ticketOpen, setTicketOpen] = useState(false);
   const connected = useWS();
   const prices = usePrices();
   const risk = useRisk();
@@ -233,11 +236,11 @@ export default function Page() {
 
       <div style={{display:"grid", gridTemplateColumns:"2fr 1fr", gap:12, marginTop:12}}>
         <div style={{display:"flex", flexDirection:"column", gap:12}}>
-          {/* Reserved for future chart/workspace content */}
+          <LiveChart symbol={ticker} />
         </div>
         <div style={{display:"flex", flexDirection:"column", gap:12}}>
-          <NarrativeTicker symbol={ticker} />
-          <PositionCoach symbol={ticker} />
+          {process.env.NEXT_PUBLIC_DISABLE_NARRATOR === '1' ? null : <NarrativeTicker symbol={ticker} />}
+          {process.env.NEXT_PUBLIC_DISABLE_NARRATOR === '1' ? null : <PositionCoach symbol={ticker} />}
           <NewsPanel symbols={(wl.data?.symbols ?? [ticker]).slice(0,7)} />
           <AlertsPanel />
         </div>
@@ -247,12 +250,13 @@ export default function Page() {
       <div style={{position:"fixed", left:0, right:0, bottom:8, display:"flex", gap:8, justifyContent:"center"}}
         className="mobile-only">
         <div className="card" style={{display:"flex", gap:8, padding:8}}>
-          <button className="secondary" onClick={()=>alert("Buy ticket (stub)")}>Buy</button>
-          <button className="secondary" onClick={()=>alert("Sell/Close (stub)")}>Sell</button>
+          <button className="secondary" onClick={()=>setTicketOpen(true)}>Buy</button>
+          <button className="secondary" onClick={()=>setTicketOpen(true)}>Sell</button>
           <button className="secondary" onClick={()=>alert("Alert preset (stub)")}>Alert</button>
           <button className="secondary" onClick={()=>alert("Ask Coach (stub)")}>Coach</button>
         </div>
       </div>
+      <OrderTicket symbol={ticker} open={ticketOpen} onClose={()=> setTicketOpen(false)} />
     </main>
   );
 }

--- a/trading-dashboard/app/page.tsx
+++ b/trading-dashboard/app/page.tsx
@@ -75,6 +75,14 @@ export default function Page() {
       return apiPost("/api/v1/compose-and-analyze", body);
     }
   });
+  const levels = useMemo(() => {
+    const data = (analyze?.data as any)?.data || analyze?.data as any;
+    const p = data?.plan;
+    if (p) {
+      return { entry: Number(p.entry), stop: Number(p.stop), tp1: Number(p.tp1), tp2: Number(p.tp2) };
+    }
+    return {} as any;
+  }, [analyze.data]);
 
   const alertMut = useMutation({
     mutationFn: (args: {symbol:string; timeframe?: 'minute'|'day'; type: 'price_above'|'price_below'; value:number; threshold_pct?: number}) =>
@@ -236,7 +244,7 @@ export default function Page() {
 
       <div style={{display:"grid", gridTemplateColumns:"2fr 1fr", gap:12, marginTop:12}}>
         <div style={{display:"flex", flexDirection:"column", gap:12}}>
-          <LiveChart symbol={ticker} />
+          <LiveChart symbol={ticker} levels={levels} />
         </div>
         <div style={{display:"flex", flexDirection:"column", gap:12}}>
           {process.env.NEXT_PUBLIC_DISABLE_NARRATOR === '1' ? null : <NarrativeTicker symbol={ticker} />}
@@ -272,7 +280,8 @@ function bandMeta(score?: number): { label: string; color: string } {
 }
 
 function ConfidencePanel({ ticker, analyze }: { ticker: string; analyze: any }) {
-  const data = analyze?.data;
+  const raw = analyze?.data as any;
+  const data = (raw?.data || raw) as any;
   const analysis = data?.analysis || null;
   const score: number | undefined = analysis?.score;
   const meta = bandMeta(score);

--- a/trading-dashboard/app/premarket/page.tsx
+++ b/trading-dashboard/app/premarket/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiPost } from "@/src/lib/api";
+
+type PlanCard = { horizon: string; why?: string[]; triggers?: string[] };
+type Primer = { symbols: string[]; items: Record<string, PlanCard[]> };
+
+async function fetchPrimer(): Promise<Primer> {
+  try {
+    const res = await fetch(`/api/proxy?path=${encodeURIComponent("/playbook/primer")}`, { cache: "no-store" });
+    if (!res.ok) throw new Error("primer missing");
+    return await res.json();
+  } catch {
+    // stub fallback
+    return {
+      symbols: ["SPY", "QQQ", "AAPL"],
+      items: {
+        SPY: [
+          { horizon: "scalp", why: ["VWAP support", "ATR regime healthy"], triggers: ["break above ORH"] },
+          { horizon: "intraday", why: ["EMA 9/20 up"], triggers: ["pullback to EMA20"] },
+          { horizon: "swing", why: ["Range expansion"], triggers: ["close > PDH"] },
+        ],
+      },
+    };
+  }
+}
+
+export default function Page() {
+  const [data, setData] = useState<Primer | null>(null);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => { fetchPrimer().then(setData).catch(e=>setError(String(e))); }, []);
+
+  const handleSize = async (symbol: string) => {
+    try { await apiPost("/sizing/suggest", { symbol, side: "long", risk_R: 1, per_unit_risk: 1 }); alert("Sized (stub)"); } catch(e:any){ alert(e?.message ?? e); }
+  };
+  const handleAlert = async (symbol: string) => {
+    try { await apiPost("/alerts/set", { symbol, timeframe:"day", condition:{type:"price_above", value: 1} }); alert("Alert created (stub)"); } catch(e:any){ alert(e?.message ?? e); }
+  };
+
+  return (
+    <main className="container">
+      <h1 style={{marginBottom:12}}>Premarket Playbook</h1>
+      {error ? <div style={{color:'#ffb4b4'}}>Error: {error}</div> : null}
+      {!data ? <div>Loading…</div> : (
+        <div style={{display:"flex", flexDirection:"column", gap:12}}>
+          {data.symbols.map(sym => (
+            <section key={sym} className="card">
+              <div style={{fontWeight:700, marginBottom:6}}>{sym}</div>
+              <div style={{display:"grid", gridTemplateColumns:"repeat(auto-fit,minmax(240px,1fr))", gap:12}}>
+                {(data.items[sym] || []).map((pc, i) => (
+                  <div key={i} className="card" style={{margin:0}}>
+                    <div style={{fontWeight:700}}>{pc.horizon.toUpperCase()}</div>
+                    <ul className="small" style={{margin:"4px 0 0 16px"}}>
+                      {(pc.why || []).map((w, j)=>(<li key={j}>{w}</li>))}
+                    </ul>
+                    <div className="small" style={{opacity:.8, marginTop:6}}>
+                      {(pc.triggers || []).join(" · ")}
+                    </div>
+                    <div style={{display:"flex", gap:8, marginTop:8}}>
+                      <button className="secondary" onClick={()=>handleSize(sym)}>Size It</button>
+                      <button className="secondary" onClick={()=>handleAlert(sym)}>Create Alert</button>
+                      <button className="secondary" onClick={()=>alert("Explain plan (stub)")}>Explain Plan</button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+

--- a/trading-dashboard/components/AskCoachWidget.tsx
+++ b/trading-dashboard/components/AskCoachWidget.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { apiPost } from "@/src/lib/api";
+
+export default function AskCoachWidget() {
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState("");
+  const [pending, setPending] = useState(false);
+  const [reply, setReply] = useState("");
+
+  const send = async () => {
+    const text = input.trim(); if (!text) return;
+    setPending(true); setReply("");
+    try {
+      const resp = await apiPost("/api/v1/coach/chat", { messages: [{ role: 'user', content: text }] });
+      setReply((resp?.content || '').toString());
+    } catch (e: any) {
+      setReply(`Error: ${e?.message ?? e}`);
+    } finally { setPending(false); }
+  };
+
+  return (
+    <div style={{position:'fixed', right:12, bottom:12, zIndex:55}}>
+      {!open ? (
+        <button className="secondary" onClick={()=> setOpen(true)}>Ask Coach</button>
+      ) : (
+        <div className="card" style={{width:320}}>
+          <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
+            <div style={{fontWeight:700}}>Ask Coach</div>
+            <button className="secondary" onClick={()=> setOpen(false)}>Close</button>
+          </div>
+          <div className="small" style={{whiteSpace:'pre-wrap', minHeight:80, marginTop:6}}>{reply || '—'}</div>
+          <div style={{display:'flex', gap:6, marginTop:6}}>
+            <input className="input" value={input} onChange={e=> setInput(e.target.value)} placeholder="e.g., What about SPY scalp?" onKeyDown={e=> { if(e.key==='Enter') send(); }} />
+            <button onClick={send} disabled={pending}>{pending? '...' : 'Send'}</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/trading-dashboard/components/CommandPalette.tsx
+++ b/trading-dashboard/components/CommandPalette.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useHotkeys } from "@/src/lib/useHotkeys";
+
+type Props = { onClose?: ()=>void };
+
+export default function CommandPalette({ onClose }: Props) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  useEffect(() => {
+    const on = (e: KeyboardEvent) => {
+      const meta = e.metaKey || e.ctrlKey; if (meta && e.key.toLowerCase() === "k") { e.preventDefault(); setOpen(v=>!v); }
+    };
+    window.addEventListener("keydown", on); return () => window.removeEventListener("keydown", on);
+  }, []);
+  useHotkeys({
+    "b": ()=> console.log("Open buy ticket"),
+    "s": ()=> console.log("Sell/Close"),
+    "a": ()=> console.log("Create alert preset"),
+    "c": ()=> console.log("Re-analyze")
+  });
+
+  if (!open) return null;
+  return (
+    <div style={{position:"fixed", inset:0, background:"rgba(0,0,0,0.4)", display:"flex", alignItems:"flex-start", justifyContent:"center", paddingTop:80, zIndex:50}} onClick={()=>{ setOpen(false); onClose?.(); }}>
+      <div className="card" style={{width:"min(720px,90vw)"}} onClick={(e)=> e.stopPropagation()}>
+        <input autoFocus placeholder="Type a command…" className="input" value={q} onChange={(e)=> setQ(e.target.value)} />
+        <div className="small" style={{opacity:.7, marginTop:6}}>Try: buy ticket (b), sell/close (s), set alert (a), reanalyze (c)</div>
+      </div>
+    </div>
+  );
+}
+

--- a/trading-dashboard/components/ConfidenceCard.tsx
+++ b/trading-dashboard/components/ConfidenceCard.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import EdgeRing from "@/components/EdgeRing";
+
+type Props = {
+  score: number;
+  band: "favorable" | "mixed" | "unfavorable" | string;
+  components?: Partial<Record<"ATR"|"VWAP"|"EMAs"|"Flow"|"Liquidity"|"Vol", number>>;
+};
+
+function bandColor(b: string) {
+  return b === "favorable" ? "#46d37e" : b === "mixed" ? "#e8b44c" : "#f26666";
+}
+
+export default function ConfidenceCard({ score, band, components={} }: Props) {
+  const slices = [
+    { key: "ATR", value: Math.max(0, components.ATR ?? 10), color: "#7dd3fc" },
+    { key: "VWAP", value: Math.max(0, components.VWAP ?? 10), color: "#60a5fa" },
+    { key: "EMAs", value: Math.max(0, components.EMAs ?? 10), color: "#34d399" },
+    { key: "Flow", value: Math.max(0, components.Flow ?? 10), color: "#f472b6" },
+    { key: "Liquidity", value: Math.max(0, components.Liquidity ?? 10), color: "#fbbf24" },
+    { key: "Vol", value: Math.max(0, components.Vol ?? 10), color: "#a78bfa" },
+  ];
+  const ring = <EdgeRing size={120} stroke={10} slices={slices} />;
+  return (
+    <section className="card" style={{display:"flex", gap:12, alignItems:"center"}}>
+      <div style={{position:"relative"}}>
+        {ring}
+        <div style={{position:"absolute", left:0, top:0, width:120, height:120, display:"flex", alignItems:"center", justifyContent:"center", flexDirection:"column"}}>
+          <div style={{fontSize:22, fontWeight:800}}>{Math.round(score)}</div>
+          <div className="small" style={{color:bandColor(band)}}>{String(band).toUpperCase()}</div>
+        </div>
+      </div>
+      <div style={{display:"grid", gridTemplateColumns:"repeat(3,auto)", gap:"6px 12px", alignItems:"center"}}>
+        {slices.map(s=> (
+          <>
+            <span key={`${s.key}-k`} className="small" style={{opacity:.8}}>{s.key}</span>
+            <div key={`${s.key}-bar`} style={{width:80, height:6, background:"#1f2937", borderRadius:6, overflow:"hidden"}}>
+              <div style={{width:`${Math.min(100, (s.value/20)*100)}%`, height:"100%", background:s.color}} />
+            </div>
+            <span key={`${s.key}-v`} className="small" style={{opacity:.6}}>{Math.round(s.value)}</span>
+          </>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/trading-dashboard/components/EdgeRing.tsx
+++ b/trading-dashboard/components/EdgeRing.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+type Slice = { key: string; value: number; color: string };
+type Props = { size?: number; stroke?: number; slices: Slice[] };
+
+export default function EdgeRing({ size=120, stroke=10, slices }: Props) {
+  const r = (size - stroke) / 2;
+  const c = size / 2;
+  const circ = 2 * Math.PI * r;
+  const total = Math.max(1, slices.reduce((a, s)=> a + Math.max(0, s.value), 0));
+  let acc = 0;
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <circle cx={c} cy={c} r={r} fill="none" stroke="#1f2937" strokeWidth={stroke} />
+      {slices.map((s, i) => {
+        const frac = Math.max(0, s.value) / total;
+        const len = frac * circ;
+        const dash = `${len} ${circ - len}`;
+        const rot = (acc / total) * 360 - 90; // start at top
+        acc += Math.max(0, s.value);
+        return (
+          <circle key={s.key} cx={c} cy={c} r={r} fill="none" stroke={s.color} strokeWidth={stroke}
+            strokeDasharray={dash} transform={`rotate(${rot} ${c} ${c})`} strokeLinecap="butt" />
+        );
+      })}
+    </svg>
+  );
+}
+

--- a/trading-dashboard/components/LiveChart.tsx
+++ b/trading-dashboard/components/LiveChart.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createChart, ISeriesApi, UTCTimestamp } from "lightweight-charts";
+
+type Bar = { t: number; o: number; h: number; l: number; c: number; v: number };
+type Props = { symbol: string };
+
+function toLw(bar: Bar) {
+  return { time: (bar.t/1000) as UTCTimestamp, open: bar.o, high: bar.h, low: bar.l, close: bar.c };
+}
+
+export default function LiveChart({ symbol }: Props) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const chart = createChart(ref.current, { width: ref.current.clientWidth, height: 280, layout: { textColor: '#ddd', background: { type: 'solid', color: '#0b0b0b' }}, grid: { vertLines: { color: '#111' }, horzLines: { color: '#111' }}});
+    const candle = chart.addCandlestickSeries({});
+    const ema9: ISeriesApi<'Line'> = chart.addLineSeries({ color: '#22d3ee', lineWidth: 1 });
+    const ema20: ISeriesApi<'Line'> = chart.addLineSeries({ color: '#a3e635', lineWidth: 1 });
+
+    let cleanup = () => { chart.remove(); };
+
+    (async () => {
+      try {
+        const path = `/market/bars?symbol=${encodeURIComponent(symbol)}&tf=1m`;
+        const res = await fetch(`/api/proxy?path=${encodeURIComponent(path)}`, { cache: 'no-store' });
+        const js = await res.json();
+        const items: Bar[] = Array.isArray(js?.items) ? js.items : [];
+        candle.setData(items.map(toLw));
+        // compute EMAs on close
+        const closes = items.map(b=> b.c);
+        const ema = (w: number) => {
+          const out: { time: UTCTimestamp, value: number }[] = [];
+          const k = 2 / (w+1);
+          let e = 0;
+          for (let i=0;i<closes.length;i++) {
+            const x = closes[i];
+            if (i < w) {
+              e += x;
+              out.push({ time: (items[i].t/1000) as UTCTimestamp, value: NaN });
+              if (i===w-1) e/=w;
+              continue;
+            }
+            e = x*k + e*(1-k);
+            out.push({ time: (items[i].t/1000) as UTCTimestamp, value: e });
+          }
+          return out;
+        };
+        ema9.setData(ema(9));
+        ema20.setData(ema(20));
+      } catch {}
+    })();
+
+    const onResize = () => {
+      if (ref.current) chart.applyOptions({ width: ref.current.clientWidth });
+    };
+    window.addEventListener('resize', onResize);
+    return () => { window.removeEventListener('resize', onResize); cleanup(); };
+  }, [symbol]);
+
+  return (
+    <section className="card">
+      <div style={{fontWeight:600, marginBottom:6}}>Live Chart — {symbol}</div>
+      <div ref={ref} />
+    </section>
+  );
+}
+

--- a/trading-dashboard/components/LiveChart.tsx
+++ b/trading-dashboard/components/LiveChart.tsx
@@ -2,23 +2,33 @@
 
 import { useEffect, useRef } from "react";
 import { createChart, ISeriesApi, UTCTimestamp } from "lightweight-charts";
+import { usePrices } from "@/src/lib/store";
 
 type Bar = { t: number; o: number; h: number; l: number; c: number; v: number };
-type Props = { symbol: string };
+type Levels = { entry?: number; stop?: number; tp1?: number; tp2?: number };
+type Props = { symbol: string; levels?: Levels };
 
 function toLw(bar: Bar) {
   return { time: (bar.t/1000) as UTCTimestamp, open: bar.o, high: bar.h, low: bar.l, close: bar.c };
 }
 
-export default function LiveChart({ symbol }: Props) {
+export default function LiveChart({ symbol, levels }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
+  const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+  const levelLinesRef = useRef<any[]>([]);
+  const vwapRef = useRef<ISeriesApi<'Line'> | null>(null);
+  const priceLineRef = useRef<any | null>(null);
+  const prices = usePrices();
 
   useEffect(() => {
     if (!ref.current) return;
     const chart = createChart(ref.current, { width: ref.current.clientWidth, height: 280, layout: { textColor: '#ddd', background: { type: 'solid', color: '#0b0b0b' }}, grid: { vertLines: { color: '#111' }, horzLines: { color: '#111' }}});
     const candle = chart.addCandlestickSeries({});
+    candleRef.current = candle;
     const ema9: ISeriesApi<'Line'> = chart.addLineSeries({ color: '#22d3ee', lineWidth: 1 });
     const ema20: ISeriesApi<'Line'> = chart.addLineSeries({ color: '#a3e635', lineWidth: 1 });
+    const vwap = chart.addLineSeries({ color: '#60a5fa', lineWidth: 1 });
+    vwapRef.current = vwap;
 
     let cleanup = () => { chart.remove(); };
 
@@ -50,6 +60,17 @@ export default function LiveChart({ symbol }: Props) {
         };
         ema9.setData(ema(9));
         ema20.setData(ema(20));
+        // simple anchored VWAP across series
+        const vwapData: { time: UTCTimestamp, value: number }[] = [];
+        let pv = 0, vol = 0;
+        for (const b of items) {
+          const price = (b.o + b.h + b.l + b.c) / 4;
+          pv += price * (b.v || 0);
+          vol += (b.v || 0);
+          const val = vol > 0 ? pv / vol : NaN;
+          vwapData.push({ time: (b.t/1000) as UTCTimestamp, value: val });
+        }
+        vwap.setData(vwapData);
       } catch {}
     })();
 
@@ -60,6 +81,42 @@ export default function LiveChart({ symbol }: Props) {
     return () => { window.removeEventListener('resize', onResize); cleanup(); };
   }, [symbol]);
 
+  // Update or render horizontal lines for levels
+  useEffect(() => {
+    // Clear existing level lines
+    if (candleRef.current && levelLinesRef.current.length) {
+      for (const line of levelLinesRef.current) {
+        try { candleRef.current.removePriceLine(line); } catch {}
+      }
+      levelLinesRef.current = [];
+    }
+    if (!candleRef.current || !levels) return;
+    const addLine = (price?: number, color?: string, title?: string) => {
+      if (price === undefined || price === null || !Number.isFinite(price)) return;
+      try {
+        const line = candleRef.current!.createPriceLine({ price, color: color || '#94a3b8', lineWidth: 1, lineStyle: 2, axisLabelVisible: true, title });
+        levelLinesRef.current.push(line);
+      } catch {}
+    };
+    addLine(levels.entry, '#60a5fa', 'Entry');
+    addLine(levels.stop, '#f87171', 'Stop');
+    addLine(levels.tp1, '#a7f3d0', 'TP1');
+    addLine(levels.tp2, '#34d399', 'TP2');
+  }, [levels]);
+
+  // Live price line updates
+  useEffect(() => {
+    const last = prices?.[symbol];
+    if (!candleRef.current || last === undefined) return;
+    try {
+      if (priceLineRef.current) {
+        candleRef.current.removePriceLine(priceLineRef.current);
+        priceLineRef.current = null;
+      }
+      priceLineRef.current = candleRef.current.createPriceLine({ price: Number(last), color: '#f59e0b', lineWidth: 1, lineStyle: 0, axisLabelVisible: true, title: 'Last' });
+    } catch {}
+  }, [prices, symbol]);
+
   return (
     <section className="card">
       <div style={{fontWeight:600, marginBottom:6}}>Live Chart — {symbol}</div>
@@ -67,4 +124,3 @@ export default function LiveChart({ symbol }: Props) {
     </section>
   );
 }
-

--- a/trading-dashboard/components/NarrativeTicker.tsx
+++ b/trading-dashboard/components/NarrativeTicker.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useMemo } from "react";
+import { useEventSource } from "@/src/lib/useEventSource";
+
+type Props = { symbol: string };
+
+function timeAgo(ms?: number) {
+  if (!ms) return "now";
+  const s = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60); if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60); return `${h}h ago`;
+}
+
+function BandChip({ band }: { band?: string }) {
+  const color = band === "favorable" ? "#46d37e" : band === "mixed" ? "#e8b44c" : "#f26666";
+  return <span style={{border:`1px solid ${color}`, color, padding:"1px 6px", borderRadius:10, fontSize:12}}>{band || "—"}</span>;
+}
+
+export default function NarrativeTicker({ symbol }: Props) {
+  const url = useMemo(() => `/api/proxy?path=/coach/stream&symbol=${encodeURIComponent(symbol)}`, [symbol]);
+  const { status, messages } = useEventSource(url, [url]);
+
+  return (
+    <section className="card" style={{minHeight:120}}>
+      <div style={{display:"flex", justifyContent:"space-between", alignItems:"center"}}>
+        <div style={{fontWeight:600}}>Trade Narrator — {symbol}</div>
+        <div className="small" style={{opacity:.8}}>{status === "open" ? "Live" : status === "connecting" ? "Connecting…" : "Idle"}</div>
+      </div>
+
+      <div style={{display:"flex", flexDirection:"column", gap:8, marginTop:8}}>
+        {messages.length === 0 ? (
+          <div className="small" style={{opacity:.7}}>Waiting for guidance…</div>
+        ) : messages.map((m: any, i: number) => {
+          const g = (m?.guidance) || {};
+          const lev = g?.stops || {};
+          const why: string[] = (Array.isArray(g?.why) ? g.why : []).slice(0, 3);
+          const horiz = g?.horizon || "intra";
+          return (
+            <div key={i} className="card" style={{margin:0}}>
+              <div style={{display:"flex", justifyContent:"space-between", alignItems:"center", gap:8}}>
+                <div className="small" style={{display:"flex", alignItems:"center", gap:8}}>
+                  <span style={{fontWeight:700}}>[{horiz.toUpperCase()}]</span>
+                  <BandChip band={g?.band} />
+                </div>
+                <div className="small" style={{opacity:.7}}>{timeAgo(m?.t_ms)}</div>
+              </div>
+              <div style={{fontWeight:700, marginTop:4}}>{g?.action || "—"}</div>
+              {why.length ? (
+                <ul className="small" style={{margin:"4px 0 0 16px"}}>
+                  {why.map((w, j)=> <li key={j}>{w}</li>)}
+                </ul>
+              ) : null}
+              <div className="small" style={{display:"flex", gap:12, marginTop:6, opacity:.85}}>
+                {lev?.sl !== undefined ? <span>SL {lev.sl}</span> : null}
+                {lev?.tp1 !== undefined ? <span>TP1 {lev.tp1}</span> : null}
+                {lev?.tp2 !== undefined ? <span>TP2 {lev.tp2}</span> : null}
+              </div>
+              {g?.risk_notes ? <div className="small" style={{textAlign:"right", opacity:.75, marginTop:4}}>{g.risk_notes}</div> : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+

--- a/trading-dashboard/components/OrderTicket.tsx
+++ b/trading-dashboard/components/OrderTicket.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = { symbol: string; open: boolean; onClose: ()=>void };
+
+export default function OrderTicket({ symbol, open, onClose }: Props) {
+  const [side, setSide] = useState<'buy'|'sell'>('buy');
+  const [qty, setQty] = useState<string>('1');
+  const [type, setType] = useState<'market'|'limit'>('market');
+  const [limit, setLimit] = useState<string>('');
+  const [sl, setSl] = useState<string>('');
+  const [tp, setTp] = useState<string>('');
+  const [preview, setPreview] = useState(true);
+  const [pending, setPending] = useState(false);
+  const [result, setResult] = useState<any>(null);
+
+  if (!open) return null;
+
+  const submit = async () => {
+    const q = Number(qty);
+    if (!Number.isFinite(q) || q <= 0) { alert('Invalid quantity'); return; }
+    if (type === 'limit' && !Number.isFinite(Number(limit))) { alert('Provide limit price'); return; }
+    setPending(true); setResult(null);
+    try {
+      const body: any = { symbol, side, quantity: q, order_type: type, preview };
+      if (type === 'limit') body.limit_price = Number(limit);
+      if (sl) body.bracket_stop = Number(sl);
+      if (tp) body.bracket_target = Number(tp);
+      const res = await fetch(`/api/proxy?path=${encodeURIComponent('/broker/tradier/order')}`, {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body)
+      });
+      const js = await res.json().catch(()=>({}));
+      setResult(js);
+    } catch (e: any) {
+      setResult({ ok: false, error: e?.message ?? String(e) });
+    } finally { setPending(false); }
+  };
+
+  return (
+    <div style={{position:'fixed', inset:0, background:'rgba(0,0,0,0.5)', display:'flex', alignItems:'center', justifyContent:'center', zIndex:60}} onClick={onClose}>
+      <div className="card" style={{minWidth:320, maxWidth:"90vw"}} onClick={e=> e.stopPropagation()}>
+        <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
+          <div style={{fontWeight:700}}>Order Ticket — {symbol}</div>
+          <button className="secondary" onClick={onClose}>Close</button>
+        </div>
+        <div style={{display:'grid', gridTemplateColumns:'repeat(2,1fr)', gap:8, marginTop:8}}>
+          <label>Side
+            <select className="input" value={side} onChange={e=> setSide(e.target.value as any)}>
+              <option value="buy">Buy</option>
+              <option value="sell">Sell</option>
+            </select>
+          </label>
+          <label>Qty
+            <input className="input" value={qty} onChange={e=> setQty(e.target.value)} inputMode="numeric" />
+          </label>
+          <label>Type
+            <select className="input" value={type} onChange={e=> setType(e.target.value as any)}>
+              <option value="market">Market</option>
+              <option value="limit">Limit</option>
+            </select>
+          </label>
+          <label>Limit
+            <input className="input" value={limit} onChange={e=> setLimit(e.target.value)} placeholder="—" inputMode="decimal" />
+          </label>
+          <label>Stop (bracket)
+            <input className="input" value={sl} onChange={e=> setSl(e.target.value)} placeholder="—" inputMode="decimal" />
+          </label>
+          <label>Target (bracket)
+            <input className="input" value={tp} onChange={e=> setTp(e.target.value)} placeholder="—" inputMode="decimal" />
+          </label>
+        </div>
+        <div style={{display:'flex', justifyContent:'space-between', alignItems:'center', marginTop:8}}>
+          <label className="small" style={{display:'flex', alignItems:'center', gap:6}}>
+            <input type="checkbox" checked={preview} onChange={e=> setPreview(e.target.checked)} /> Preview only
+          </label>
+          <button onClick={submit} disabled={pending}>{pending? 'Submitting…' : (preview ? 'Preview' : 'Place')}</button>
+        </div>
+        <div className="small" style={{marginTop:8, whiteSpace:'pre-wrap'}}>
+          {result ? JSON.stringify(result, null, 2) : ''}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/trading-dashboard/components/PositionCoach.tsx
+++ b/trading-dashboard/components/PositionCoach.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMemo } from "react";
+import { useEventSource } from "@/src/lib/useEventSource";
+
+type Props = { symbol: string; positionId?: string | null };
+
+export default function PositionCoach({ symbol, positionId }: Props) {
+  const url = useMemo(() => `/api/proxy?path=/coach/stream&symbol=${encodeURIComponent(symbol)}${positionId?`&position_id=${encodeURIComponent(positionId)}`:""}`,[symbol, positionId]);
+  const { status, messages } = useEventSource(url, [url]);
+  const head = messages[0] || {};
+  const g = (head?.guidance) || {};
+  const next = Array.isArray(g?.if_then) && g.if_then.length ? (g.if_then[0] || {}) : {};
+  const unless = g?.risk_notes || g?.unless || "—";
+
+  const disabled = false; // TODO: bound to risk breach from store
+
+  return (
+    <section className="card" style={{minHeight:100}}>
+      <div style={{display:"flex", justifyContent:"space-between", alignItems:"center"}}>
+        <div style={{fontWeight:600}}>Position Coach — {symbol}</div>
+        <div className="small" style={{opacity:.8}}>{status === "open" ? "Live" : status === "connecting" ? "Connecting…" : "Idle"}</div>
+      </div>
+      <div style={{display:"grid", gridTemplateColumns:"repeat(auto-fit,minmax(220px,1fr))", gap:12, marginTop:8}}>
+        <div className="card" style={{margin:0}}>
+          <div style={{fontWeight:700, marginBottom:6}}>NOW</div>
+          <div className="small">{g?.action || "—"}</div>
+        </div>
+        <div className="card" style={{margin:0}}>
+          <div style={{fontWeight:700, marginBottom:6}}>NEXT</div>
+          <div className="small">{next?.then || next?.action || "—"}</div>
+        </div>
+        <div className="card" style={{margin:0}}>
+          <div style={{fontWeight:700, marginBottom:6}}>UNLESS</div>
+          <div className="small">{unless}</div>
+        </div>
+      </div>
+      <div style={{display:"flex", gap:8, marginTop:10, flexWrap:"wrap"}}>
+        <button className="secondary" disabled={disabled} onClick={()=>console.log("Trim clicked")}>Trim</button>
+        <button className="secondary" disabled={disabled} onClick={()=>console.log("Move Stop to VWAP")}>Move Stop → VWAP</button>
+        <button className="secondary" disabled={disabled} onClick={()=>console.log("Close position")}>Close</button>
+      </div>
+    </section>
+  );
+}
+

--- a/trading-dashboard/components/PositionCoach.tsx
+++ b/trading-dashboard/components/PositionCoach.tsx
@@ -15,6 +15,32 @@ export default function PositionCoach({ symbol, positionId }: Props) {
 
   const disabled = false; // TODO: bound to risk breach from store
 
+  const postJson = async (path: string, body: any) => {
+    const res = await fetch(`/api/proxy?path=${encodeURIComponent(path)}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json().catch(()=> ({}));
+  };
+
+  const onTrim = async () => {
+    const qtyStr = window.prompt("Trim quantity (shares)", "1");
+    const qty = qtyStr ? Number(qtyStr) : NaN;
+    if (!Number.isFinite(qty) || qty <= 0) return;
+    try { await postJson("/broker/tradier/order", { symbol, side: "sell", quantity: qty, order_type: "market", preview: true }); alert("Trim preview sent"); } catch(e:any){ alert(e?.message ?? String(e)); }
+  };
+  const onMoveStopToVWAP = async () => {
+    try { await postJson("/journal/create", { symbol, notes: "Move stop to VWAP (coach action)" }); alert("Noted: Move stop to VWAP"); } catch(e:any){ alert(e?.message ?? String(e)); }
+  };
+  const onClose = async () => {
+    const qtyStr = window.prompt("Close quantity (shares)", "1");
+    const qty = qtyStr ? Number(qtyStr) : NaN;
+    if (!Number.isFinite(qty) || qty <= 0) return;
+    try { await postJson("/broker/tradier/order", { symbol, side: "sell", quantity: qty, order_type: "market", preview: true }); alert("Close preview sent"); } catch(e:any){ alert(e?.message ?? String(e)); }
+  };
+
   return (
     <section className="card" style={{minHeight:100}}>
       <div style={{display:"flex", justifyContent:"space-between", alignItems:"center"}}>
@@ -36,11 +62,10 @@ export default function PositionCoach({ symbol, positionId }: Props) {
         </div>
       </div>
       <div style={{display:"flex", gap:8, marginTop:10, flexWrap:"wrap"}}>
-        <button className="secondary" disabled={disabled} onClick={()=>console.log("Trim clicked")}>Trim</button>
-        <button className="secondary" disabled={disabled} onClick={()=>console.log("Move Stop to VWAP")}>Move Stop → VWAP</button>
-        <button className="secondary" disabled={disabled} onClick={()=>console.log("Close position")}>Close</button>
+        <button className="secondary" disabled={disabled} onClick={onTrim}>Trim</button>
+        <button className="secondary" disabled={disabled} onClick={onMoveStopToVWAP}>Move Stop → VWAP</button>
+        <button className="secondary" disabled={disabled} onClick={onClose}>Close</button>
       </div>
     </section>
   );
 }
-

--- a/trading-dashboard/package.json
+++ b/trading-dashboard/package.json
@@ -70,3 +70,4 @@
     "typescript": "^5"
   }
 }
+    "lightweight-charts": "^4.2.0",

--- a/trading-dashboard/src/lib/useEventSource.ts
+++ b/trading-dashboard/src/lib/useEventSource.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export type SseStatus = "idle" | "connecting" | "open" | "closed";
+
+export function useEventSource(url: string, deps: any[] = []) {
+  const [status, setStatus] = useState<SseStatus>("idle");
+  const [messages, setMessages] = useState<any[]>([]);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    setStatus("connecting");
+    // Close any existing connection first
+    if (esRef.current) { esRef.current.close(); esRef.current = null; }
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    es.onopen = () => setStatus("open");
+    es.onerror = () => {
+      setStatus("closed");
+    };
+    es.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data);
+        setMessages(prev => [data, ...prev].slice(0, 50));
+      } catch {
+        // Heartbeats or malformed payloads ignored
+      }
+    };
+    return () => { es.close(); esRef.current = null; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { status, messages };
+}
+

--- a/trading-dashboard/src/lib/useHotkeys.ts
+++ b/trading-dashboard/src/lib/useHotkeys.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+
+type Handler = (e: KeyboardEvent) => void;
+
+function isTypingTarget(el: Element | null) {
+  if (!el) return false;
+  const tag = (el as HTMLElement).tagName?.toLowerCase();
+  return tag === "input" || tag === "textarea" || (el as HTMLElement).isContentEditable;
+}
+
+export function useHotkeys(map: Record<string, Handler>) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (isTypingTarget(document.activeElement)) return;
+      const key = e.key.toLowerCase();
+      const handler = map[key];
+      if (handler) {
+        handler(e);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [map]);
+}
+


### PR DESCRIPTION
Implements core UX deliverables:\n\n- Trade Narrator: SSE-driven list via /api/proxy?path=/coach/stream&symbol=SYMBOL; streaming pass-through on Edge runtime proxy\n- Position Coach: NOW/NEXT/UNLESS blocks with quick-action placeholders\n- ConfidenceCard v2: EdgeRing segmented gauge by ATR/VWAP/EMAs/Flow/Liquidity/Vol\n- Premarket Playbook: primer page with horizon cards and stubbed actions\n- Real News Panel: server-driven headlines from /news via proxy, refreshable\n- Hooks: useEventSource (SSE), useHotkeys; CommandPalette (Cmd/Ctrl+K)\n\nAcceptance: basic UI renders, SSE connects; News displays headlines; TODO: integrate into main dashboard routes as desired.\n\nNote: lightweight implementation favors simplicity; safe fallbacks for missing endpoints.